### PR TITLE
fix: use explicit default branch in test setup for CI compatibility

### DIFF
--- a/lib/git-harvest.test.ts
+++ b/lib/git-harvest.test.ts
@@ -60,7 +60,7 @@ let repo: string;
 // テストごとに origin 付きリポジトリを作成
 beforeEach(() => {
   bare = mkdtempSync(join(tmpdir(), 'git-harvest-bare-'));
-  execSync(`git init --bare ${bare}`);
+  execSync(`git init --bare -b main ${bare}`);
   repo = mkdtempSync(join(tmpdir(), 'git-harvest-work-'));
   execSync(`git clone ${bare} ${repo}`);
   git(repo, 'config user.email "test@test.com"');


### PR DESCRIPTION
## Summary

CI 環境でテストが失敗する問題を修正。

## 変更内容

- `git init --bare` → `git init --bare -b main` に変更し、デフォルトブランチを明示的に指定
- CI 環境（Ubuntu）では `init.defaultBranch` が未設定のため `master` になり、テスト内の `git checkout main` が失敗していた

## Test plan

- [x] `bun test` 全 19 テスト pass（ローカル確認済み）
- [ ] CI でテストが pass することを確認