### PR TITLE
docs: update README usage commands with @latest and bunx

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -7,13 +7,14 @@
 ## 使い方
 
 ```sh
-pnpx git-harvest
-```
+# bun
+bunx git-harvest@latest
 
-npm の場合:
+# pnpm
+pnpx git-harvest@latest
 
-```sh
-npx git-harvest
+# npm
+npx -y git-harvest@latest
 ```
 
 ### オプション
@@ -42,5 +43,7 @@ git-harvest --version  # バージョンを表示
 post-merge:
   commands:
     cleanup-merged:
-      run: pnpx git-harvest
+      run: pnpx git-harvest@latest
+      # or: bunx git-harvest@latest
+      # or: npx -y git-harvest@latest
 ```

--- a/README.md
+++ b/README.md
@@ -7,13 +7,14 @@ Clean up merged branches and worktrees (supports squash merges).
 ## Usage
 
 ```sh
-pnpx git-harvest
-```
+# bun
+bunx git-harvest@latest
 
-With npm:
+# pnpm
+pnpx git-harvest@latest
 
-```sh
-npx git-harvest
+# npm
+npx -y git-harvest@latest
 ```
 
 ### Options
@@ -42,5 +43,7 @@ Uses `git commit-tree` to create a virtual squash commit and `git cherry` to che
 post-merge:
   commands:
     cleanup-merged:
-      run: pnpx git-harvest
+      run: pnpx git-harvest@latest
+      # or: bunx git-harvest@latest
+      # or: npx -y git-harvest@latest
 ```


### PR DESCRIPTION
## Summary

- 実行コマンドに `@latest` を追加し、常に最新版が使われるように修正
- `bunx` をプライマリの実行方法として追加
- `npx` に `-y` フラグを追加（確認プロンプトをスキップ）
- lefthook の例を pnpm メインに変更し、bun/npm をコメントで補足

Closes #7