### PR TITLE
feat: add curl-based install and uninstall scripts

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,6 +33,23 @@ jobs:
           config-file: .github/.release-please-config.json
           manifest-file: .github/.release-please-manifest.json
 
+  upload-assets:
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Upload release assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "${{ needs.release-please.outputs.tag_name }}" lib/git-harvest
+
   npm-publish:
     needs: release-please
     if: needs.release-please.outputs.release_created == 'true'

--- a/README.ja.md
+++ b/README.ja.md
@@ -4,7 +4,25 @@
 
 マージ済みブランチと worktree を自動で整理するツール（squash merge 対応）。
 
+## インストール
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/nozomiishii/git-harvest/main/install.sh | bash
+```
+
+### アンインストール
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/nozomiishii/git-harvest/main/uninstall.sh | bash
+```
+
 ## 使い方
+
+```sh
+git-harvest
+```
+
+インストールせずに直接実行する場合:
 
 ```sh
 # bun

--- a/README.md
+++ b/README.md
@@ -4,7 +4,25 @@ English | [日本語](./README.ja.md)
 
 Clean up merged branches and worktrees (supports squash merges).
 
+## Install
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/nozomiishii/git-harvest/main/install.sh | bash
+```
+
+### Uninstall
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/nozomiishii/git-harvest/main/uninstall.sh | bash
+```
+
 ## Usage
+
+```sh
+git-harvest
+```
+
+Or run directly without installing:
 
 ```sh
 # bun

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# git-harvest — installer
+# Usage: curl -fsSL https://raw.githubusercontent.com/nozomiishii/git-harvest/main/install.sh | bash
+set -euo pipefail
+
+REPO="nozomiishii/git-harvest"
+BIN_DIR="${XDG_BIN_HOME:-$HOME/.local/bin}"
+
+# ---------------------------------------------------------------------------
+# Download script from GitHub Releases
+# ---------------------------------------------------------------------------
+download() {
+  local version="${GIT_HARVEST_VERSION:-latest}"
+  local base_url
+
+  if [ "$version" = "latest" ]; then
+    base_url="https://github.com/${REPO}/releases/latest/download"
+  else
+    base_url="https://github.com/${REPO}/releases/download/${version}"
+  fi
+
+  local script_url="${base_url}/git-harvest"
+
+  mkdir -p "$BIN_DIR"
+
+  echo "Downloading git-harvest..."
+
+  if command -v curl >/dev/null; then
+    curl -fsSL "$script_url" -o "$BIN_DIR/git-harvest"
+  elif command -v wget >/dev/null; then
+    wget -qO "$BIN_DIR/git-harvest" "$script_url"
+  else
+    echo "Error: curl or wget is required" >&2
+    exit 1
+  fi
+
+  chmod +x "$BIN_DIR/git-harvest"
+}
+
+# ---------------------------------------------------------------------------
+# Configure shell (.zshrc)
+# ---------------------------------------------------------------------------
+configure_shell() {
+  local zshrc="$HOME/.zshrc"
+  # shellcheck disable=SC2016
+  local marker='# git-harvest'
+
+  # Skip if already configured
+  if [ -f "$zshrc" ] && grep -qF "$marker" "$zshrc"; then
+    echo "Shell already configured in $zshrc"
+    return
+  fi
+
+  local config_block
+  config_block=$(cat <<'BLOCK'
+
+# git-harvest
+export PATH="${XDG_BIN_HOME:-$HOME/.local/bin}:$PATH"
+BLOCK
+)
+
+  if [ -f "$zshrc" ]; then
+    echo "$config_block" >> "$zshrc"
+  else
+    echo "$config_block" > "$zshrc"
+  fi
+
+  echo "Added git-harvest configuration to $zshrc"
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+main() {
+  download
+  configure_shell
+
+  echo ""
+  echo "git-harvest was installed successfully!"
+  echo "  Binary: $BIN_DIR/git-harvest"
+  echo ""
+  echo "Restart your terminal or run:"
+  echo "  source ~/.zshrc"
+}
+
+main

--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
     "lib/git-harvest"
   ],
   "scripts": {
-    "test": "bun test"
+    "test": "bun test",
+    "install:local": "bash install.sh",
+    "uninstall:local": "bash uninstall.sh"
   },
   "devDependencies": {
     "@types/bun": "1.3.11"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# git-harvest — uninstaller
+# Usage: curl -fsSL https://raw.githubusercontent.com/nozomiishii/git-harvest/main/uninstall.sh | bash
+set -euo pipefail
+
+BIN_DIR="${XDG_BIN_HOME:-$HOME/.local/bin}"
+
+# ---------------------------------------------------------------------------
+# Confirm before uninstalling
+# ---------------------------------------------------------------------------
+confirm_uninstall() {
+  echo "The following will be removed:"
+  echo "  Binary: $BIN_DIR/git-harvest"
+  echo "  Shell:  git-harvest block in ~/.zshrc"
+  echo ""
+
+  local answer=""
+  if [ -t 0 ]; then
+    read -rp "Continue? [Y/n] " answer
+  elif [ -e /dev/tty ]; then
+    read -rp "Continue? [Y/n] " answer < /dev/tty
+  fi
+
+  case "$answer" in
+    [nN]*) echo "Aborted."; exit 0 ;;
+  esac
+}
+
+# ---------------------------------------------------------------------------
+# Remove binary
+# ---------------------------------------------------------------------------
+remove_binary() {
+  if [ -f "$BIN_DIR/git-harvest" ]; then
+    rm -f "$BIN_DIR/git-harvest"
+    echo "Removed $BIN_DIR/git-harvest"
+  else
+    echo "Binary not found: $BIN_DIR/git-harvest (skipped)"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Remove git-harvest block from .zshrc
+# ---------------------------------------------------------------------------
+unconfigure_shell() {
+  local zshrc="$HOME/.zshrc"
+  local marker='# git-harvest'
+
+  if [ ! -f "$zshrc" ]; then
+    echo "No .zshrc found (skipped)"
+    return
+  fi
+
+  if ! grep -qF "$marker" "$zshrc"; then
+    echo "No git-harvest configuration found in $zshrc (skipped)"
+    return
+  fi
+
+  local tmp
+  tmp="$(mktemp)"
+
+  # Delete the block: comment line through export line
+  sed '/^# git-harvest$/,/^export PATH=.*\.local\/bin.*$/d' "$zshrc" > "$tmp"
+
+  # Squeeze consecutive blank lines
+  cat -s "$tmp" > "$zshrc"
+  rm -f "$tmp"
+
+  echo "Removed git-harvest configuration from $zshrc"
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+main() {
+  confirm_uninstall
+  remove_binary
+  unconfigure_shell
+
+  echo ""
+  echo "git-harvest was uninstalled successfully!"
+  echo ""
+  echo "Restart your terminal to apply changes."
+}
+
+main


### PR DESCRIPTION
## Summary

- `curl | bash` で git-harvest をインストール・アンインストールできるスクリプトを追加
- GitHub Releases にスクリプトをアセットとしてアップロードする workflow ステップを追加
- README（英語・日本語）に curl インストール手順を追記

## 変更内容

- `install.sh`: GitHub Releases からスクリプトをダウンロードし `~/.local/bin/git-harvest` に配置。`.zshrc` に PATH 設定を追加（冪等）
- `uninstall.sh`: バイナリ削除 + `.zshrc` のブロック削除（確認プロンプト付き）
- `.github/workflows/release.yaml`: `upload-assets` ジョブを追加
- `README.md` / `README.ja.md`: インストール・アンインストール手順を追記
- `package.json`: `install:local` / `uninstall:local` スクリプトを追加

## Test plan

- [x] `bun test` で既存テスト 19 件すべて通過
- [ ] `bash install.sh` でローカルインストールを実行し `~/.local/bin/git-harvest` が配置されることを確認
- [ ] `git-harvest --version` でバージョンが表示されることを確認
- [ ] `bash uninstall.sh` でアンインストールし、ファイルと `.zshrc` エントリが削除されることを確認