### PR TITLE
docs: add alias setup section to README

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -36,6 +36,18 @@ git-harvest --version  # バージョンを表示
 
 `git commit-tree` で仮想 squash コミットを作成し、`git cherry` でデフォルトブランチに含まれているかを判定します。`git branch --merged` では検出できない squash merge を正しく検出できます。
 
+## エイリアス設定
+
+お好みでエイリアスを設定すると、より手軽に実行できます。両方設定しても問題ありませんし、好きな片方だけでも OK です:
+
+```sh
+# シェルエイリアス
+alias ghv='bunx git-harvest@latest'
+
+# Git サブコマンドとして登録 — `git harvest` で実行可能
+git config --global alias.harvest '!bunx git-harvest@latest'
+```
+
 ## lefthook との連携
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -36,6 +36,18 @@ git-harvest --version  # Show version
 
 Uses `git commit-tree` to create a virtual squash commit and `git cherry` to check if the result is already included in the default branch. This correctly detects squash merges, which `git branch --merged` cannot.
 
+## Aliases
+
+Set up aliases for quicker access. You can use both or just the one you prefer:
+
+```sh
+# Shell alias
+alias ghv='bunx git-harvest@latest'
+
+# Git subcommand alias — run as `git harvest`
+git config --global alias.harvest '!bunx git-harvest@latest'
+```
+
 ## With lefthook
 
 ```yaml


### PR DESCRIPTION
## 概要

- README.md / README.ja.md にエイリアス設定セクションを追加
- シェルエイリアス (`ghv`) と Git サブコマンドエイリアス (`git harvest`) の設定例を記載
- 両方設定しても片方だけでも OK という説明を含む

## テストプラン

- [ ] README.md のエイリアスセクションが正しく表示されること
- [ ] README.ja.md のエイリアスセクションが正しく表示されること