### PR TITLE
fix: exclude merge commits from release notes

### DIFF
--- a/.github/.release-please-config.json
+++ b/.github/.release-please-config.json
@@ -5,6 +5,7 @@
   "bump-patch-for-minor-pre-major": true,
   "include-component-in-tag": false,
   "pull-request-title-pattern": "chore: release ${version}",
+  "exclude-commits-pattern": "^Merge pull request",
   "packages": {
     ".": {
       "release-type": "node",


### PR DESCRIPTION
## Summary

- release-please の設定に `exclude-commits-pattern` を追加し、`Merge pull request` コミットをリリースノートから除外

## 背景

Squash Merge 運用のリポジトリで通常マージが行われた場合、マージコミットのメッセージ（`Merge pull request #9 ...`）に含まれる PR タイトル（`feat: ...`）が release-please に拾われ、同じ機能がリリースノートに重複して掲載される問題が発生した（PR #11）。

`exclude-commits-pattern: "^Merge pull request"` を設定することで、マージコミットをリリースノート生成から除外する。

## Test plan

- [ ] この PR をマージ後、release-please が生成する次のリリース PR でマージコミットが含まれないことを確認