### PR TITLE
fix: update bootstrap-sha after history linearization

### DIFF
--- a/.github/.release-please-config.json
+++ b/.github/.release-please-config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "bootstrap-sha": "02e31e2643ee109e379e3c9f401bef006a99bd9c",
+  "bootstrap-sha": "302ed82827bc9f8c52e49ac70a32e5b5b8dc4270",
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
   "include-component-in-tag": false,


### PR DESCRIPTION
## Summary

- main ブランチの履歴をリニア化（マージコミット除去）した後、`bootstrap-sha` を新しい v0.1.2 コミット SHA に更新
- タグ `v0.1.1`, `v0.1.2` も新しい SHA に付け替え済み

## 背景

履歴のリニア化により全コミットの SHA が変わったため、release-please が v0.1.2 以前のコミットも新規と認識してリリースノートに含めてしまう問題が発生。`bootstrap-sha` を更新することで v0.1.2 以降のコミットのみを対象にする。

## Test plan

- [ ] この PR マージ後、release-please が生成するリリース PR に v0.1.2 以前のコミットが含まれないことを確認