### PR TITLE
docs: add alias setup section and git workflow guide

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -54,6 +54,18 @@ git-harvest --version  # バージョンを表示
 
 `git commit-tree` で仮想 squash コミットを作成し、`git cherry` でデフォルトブランチに含まれているかを判定します。`git branch --merged` では検出できない squash merge を正しく検出できます。
 
+## エイリアス設定
+
+お好みでエイリアスを設定すると、より手軽に実行できます。両方設定しても問題ありませんし、好きな片方だけでも OK です:
+
+```sh
+# シェルエイリアス
+alias ghv='bunx git-harvest@latest'
+
+# Git サブコマンドとして登録 — `git harvest` で実行可能
+git config --global alias.harvest '!bunx git-harvest@latest'
+```
+
 ## lefthook との連携
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -54,6 +54,18 @@ git-harvest --version  # Show version
 
 Uses `git commit-tree` to create a virtual squash commit and `git cherry` to check if the result is already included in the default branch. This correctly detects squash merges, which `git branch --merged` cannot.
 
+## Aliases
+
+Set up aliases for quicker access. You can use both or just the one you prefer:
+
+```sh
+# Shell alias
+alias ghv='bunx git-harvest@latest'
+
+# Git subcommand alias — run as `git harvest`
+git config --global alias.harvest '!bunx git-harvest@latest'
+```
+
 ## With lefthook
 
 ```yaml

--- a/docs/git-workflow.md
+++ b/docs/git-workflow.md
@@ -1,0 +1,90 @@
+# Git Workflow Guide
+
+新しいリポジトリを作成する際の Git 運用ガイド。
+main ブランチの履歴をリニアに保ち、リリースノートの重複を防ぐ構成。
+
+## GitHub リポジトリ設定
+
+### 1. PR マージ方法の制限
+
+**Settings > General > Pull Requests** で以下のように設定する。
+
+| 設定 | 値 |
+|---|---|
+| Allow merge commits | OFF |
+| Allow squash merging | ON |
+| Allow rebase merging | OFF |
+
+Squash Merge のみ許可することで、PR が main にマージされる際に全コミットが1つに潰される。
+ブランチ内でどのような履歴になっていても、main の履歴は常にリニアになる。
+
+### 2. main への直接 push 禁止（Ruleset）
+
+**Settings > Rules > Rulesets** で以下の Ruleset を作成する。
+
+- **Name**: `Protect main branch`
+- **Enforcement**: Active
+- **Target branches**: `refs/heads/main`
+- **Rules**: Require a pull request before merging（required approving review count: 0）
+
+これにより main への変更は必ず PR 経由になる。
+個人リポジトリではレビュー必須人数を 0 にしてセルフマージを許可する。
+
+gh CLI で作成する場合:
+
+```bash
+gh api repos/{owner}/{repo}/rulesets \
+  --method POST \
+  --input - <<'JSON'
+{
+  "name": "Protect main branch",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/heads/main"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": false,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": false
+      }
+    }
+  ],
+  "bypass_actors": []
+}
+JSON
+```
+
+## なぜこの構成でうまくいくのか
+
+```
+設定1: Squash Merge のみ許可
+  → main に入るコミットは常に PR ごとの 1 コミット
+  → main の履歴がリニアになる
+
+設定2: main への直接 push 禁止
+  → 全ての変更が PR 経由になる
+  → 設定1 が確実に適用される
+
+結果:
+  → release-please がコミットを正しく解析できる
+  → リリースノートに重複が発生しない
+  → git log が見やすい
+```
+
+## ローカル設定（任意）
+
+ブランチ内の履歴も綺麗に保ちたい場合は、`git pull` 時に rebase をデフォルトにできる。
+Squash Merge 運用では main の履歴には影響しないため、必須ではない。
+
+```bash
+git config pull.rebase true
+```


### PR DESCRIPTION
## Summary

- README.md / README.ja.md にエイリアス設定セクションを追加（旧 PR #10 の再作成）
- `docs/git-workflow.md` に Git 運用ガイドを追加（旧 PR #13 の再作成）

## 変更内容

### エイリアス設定（README）
- シェルエイリアス (`ghv`) と Git サブコマンドエイリアス (`git harvest`) の設定例を記載

### Git 運用ガイド（docs/git-workflow.md）
- Squash Merge のみ許可の設定
- Ruleset による main への直接 push 禁止（gh CLI での作成コマンド付き）
- なぜこの構成でリニアな履歴が保たれるかの説明

## Test plan

- [ ] README.md / README.ja.md のエイリアスセクションが正しく表示されること
- [ ] docs/git-workflow.md の内容が正確であること