### PR TITLE
docs: improve README structure and fix inconsistencies

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -2,7 +2,7 @@
 
 [English](./README.md) | 日本語
 
-マージ済みブランチと worktree を自動で整理するツール（squash merge 対応）。
+merge 済み branch と worktree を自動で整理するツール
 
 ## インストール
 
@@ -14,31 +14,36 @@ curl -fsSL https://raw.githubusercontent.com/nozomiishii/git-harvest/main/instal
 
 ターミナルを再起動するか `source ~/.zshrc` を実行すると git-harvest が使えるようになります。
 
-エイリアスを設定するとより手軽に実行できます。両方設定しても片方だけでも OK です:
-
-```sh
-# シェルエイリアス
-echo "alias ghv='git-harvest'" >> ~/.zshrc
-
-# Git サブコマンド — `git harvest` で実行可能
-git config --global alias.harvest '!git-harvest'
-```
-
 ### Homebrew
 
 ```sh
 brew install nozomiishii/tap/git-harvest
 ```
 
-#### アンインストール
+### エイリアスを設定
+
+エイリアスを設定するとより手軽に実行できます。両方設定しても片方だけでも設定できます:
+
+`ghv`
+```sh
+# シェルエイリアス
+echo "alias ghv='git-harvest'" >> ~/.zshrc
+```
+
+`git harvest`
+```sh
+# Git サブコマンド — `git harvest` で実行可能
+git config --global alias.harvest '!git-harvest'
+```
+
+
+## アンインストール
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/nozomiishii/git-harvest/main/uninstall.sh | bash
 ```
 
-### npm
-
-インストールせずに直接実行:
+## インストールせずに直接実行
 
 ```sh
 # bun
@@ -64,6 +69,26 @@ git-harvest --help     # ヘルプを表示
 git-harvest --version  # バージョンを表示
 ```
 
+## おすすめの運用法
+
+Git hooksのpost-mergeコマンドと合わせることで、Mergeやpullした際に自動で収穫もできます。
+
+### [lefthook](https://github.com/evilmartians/lefthook)との連携
+
+Git Hooks にはhusky、pre-commit、simple-git-hooks など様々なツールがありますが、Lefthook が言語に依存せず monorepo にも組み込みやすいのでおすすめです。さらに lefthook-local.yaml を使えば、チーム開発で他のメンバーに影響を与えず自分だけ実行する運用も可能です。
+
+
+```yaml
+# lefthook-local.yaml
+post-merge:
+  commands:
+    git-harvest:
+      run: npx -y git-harvest@latest
+      # or: bunx git-harvest@latest
+      # or: pnpx git-harvest@latest
+```
+
+
 ## 動作内容
 
 1. `origin/HEAD` からデフォルトブランチ（main/master）を検出
@@ -76,14 +101,3 @@ git-harvest --version  # バージョンを表示
 
 `git commit-tree` で仮想 squash コミットを作成し、`git cherry` でデフォルトブランチに含まれているかを判定します。`git branch --merged` では検出できない squash merge を正しく検出できます。
 
-## lefthook との連携
-
-```yaml
-# lefthook.yaml
-post-merge:
-  commands:
-    cleanup-merged:
-      run: pnpx git-harvest@latest
-      # or: bunx git-harvest@latest
-      # or: npx -y git-harvest@latest
-```

--- a/README.md
+++ b/README.md
@@ -14,31 +14,36 @@ curl -fsSL https://raw.githubusercontent.com/nozomiishii/git-harvest/main/instal
 
 Restart your terminal or run `source ~/.zshrc` to start using git-harvest.
 
-Set up aliases for quicker access. You can use both or just the one you prefer:
-
-```sh
-# Shell alias
-echo "alias ghv='git-harvest'" >> ~/.zshrc
-
-# Git subcommand — run as `git harvest`
-git config --global alias.harvest '!git-harvest'
-```
-
 ### Homebrew
 
 ```sh
 brew install nozomiishii/tap/git-harvest
 ```
 
-#### Uninstall
+### Set up aliases
+
+Set up aliases for quicker access. You can use both or just the one you prefer:
+
+`ghv`
+```sh
+# Shell alias
+echo "alias ghv='git-harvest'" >> ~/.zshrc
+```
+
+`git harvest`
+```sh
+# Git subcommand — run as `git harvest`
+git config --global alias.harvest '!git-harvest'
+```
+
+
+## Uninstall
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/nozomiishii/git-harvest/main/uninstall.sh | bash
 ```
 
-### npm
-
-Run directly without installing:
+## Run directly without installing
 
 ```sh
 # bun
@@ -64,26 +69,34 @@ git-harvest --help     # Show help
 git-harvest --version  # Show version
 ```
 
+## Recommended workflow
+
+By combining with Git hooks' post-merge command, you can automatically harvest after every merge or pull.
+
+### With [lefthook](https://github.com/evilmartians/lefthook)
+
+There are many Git hook tools such as husky, pre-commit, and simple-git-hooks, but Lefthook is recommended because it is language-agnostic and easy to integrate into monorepos. Additionally, by using lefthook-local.yaml, you can run hooks only for yourself without affecting other team members.
+
+
+```yaml
+# lefthook-local.yaml
+post-merge:
+  commands:
+    git-harvest:
+      run: npx -y git-harvest@latest
+      # or: bunx git-harvest@latest
+      # or: pnpx git-harvest@latest
+```
+
+
 ## What it does
 
 1. Detects the default branch (main/master) from `origin/HEAD`
 2. Finds local branches already merged into the default branch (including squash merges)
 3. Removes worktrees associated with merged branches
 4. Deletes the merged branches
-5. Prunes stale remote-tracking references
+5. Prunes stale remote-tracking references (`git fetch --prune`)
 
 ### Squash merge detection
 
 Uses `git commit-tree` to create a virtual squash commit and `git cherry` to check if the result is already included in the default branch. This correctly detects squash merges, which `git branch --merged` cannot.
-
-## With lefthook
-
-```yaml
-# lefthook.yaml
-post-merge:
-  commands:
-    cleanup-merged:
-      run: pnpx git-harvest@latest
-      # or: bunx git-harvest@latest
-      # or: npx -y git-harvest@latest
-```


### PR DESCRIPTION
## 概要
- 英語版 README の構成を日本語版に合わせて統一（セクション順序・見出しレベル）
- `lefthook-local.yml` → `lefthook-local.yaml` に表記を統一
- 日本語版の冗長な一文を分割して読みやすく改善
- 「おすすめの運用法 / Recommended workflow」セクションを両 README に追加

## テストプラン
- [ ] README.md と README.ja.md の構成が一致していることを確認
- [ ] lefthook 関連のファイル名が `.yaml` で統一されていることを確認
- [ ] リンクが正しく機能することを確認