### PR TITLE
fix: add push-to parameter to skip fork creation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -107,6 +107,7 @@ jobs:
         with:
           formula-name: git-harvest
           homebrew-tap: nozomiishii/homebrew-tap
+          push-to: nozomiishii/homebrew-tap
           tag-name: ${{ needs.release-please.outputs.tag_name }}
           create-pullrequest: false
           commit-message: |

--- a/docs/homebrew-publishing.md
+++ b/docs/homebrew-publishing.md
@@ -393,6 +393,7 @@ gh secret set OP_SERVICE_ACCOUNT_TOKEN -R nozomiishii/git-harvest
         with:
           formula-name: git-harvest
           homebrew-tap: nozomiishii/homebrew-tap
+          push-to: nozomiishii/homebrew-tap
           tag-name: ${{ needs.release-please.outputs.tag_name }}
           create-pullrequest: false
           commit-message: |
@@ -401,8 +402,10 @@ gh secret set OP_SERVICE_ACCOUNT_TOKEN -R nozomiishii/git-harvest
           COMMITTER_TOKEN: ${{ steps.app-token.outputs.token }}
 ```
 
-> `create-pullrequest: false` を明示しないと、アクションが fork → PR のフローを試みて
-> `Resource not accessible by integration` エラーになる（GitHub App には fork 作成権限がないため）。
+> GitHub App トークンを使う場合、`push-to` と `create-pullrequest: false` の両方が必要。
+> `push-to` を指定しないと、アクションが権限チェックで fork を作ろうとし
+> `Resource not accessible by integration` エラーになる
+> （GitHub App トークンでは `GET /user` API が 403 になるため）。
 
 リリースの自動化フロー:
 


### PR DESCRIPTION
## Summary

- `push-to: nozomiishii/homebrew-tap` を追加して fork 作成ロジックをスキップ
- ドキュメントに `push-to` が必要な理由を追記

## 詳細

mislav/bump-homebrew-formula-action は GitHub App トークンで `GET /user` を呼ぶと 403 になり、
push 権限がないと判定して fork を作ろうとする（`create-pullrequest: false` でも回避できない）。
`push-to` を明示的に指定することで fork ロジック自体をスキップする。

## Test plan

- [ ] マージ後の次回リリースで homebrew-update ジョブが成功すること