### PR TITLE
feat: add harvest summary display, dry-run mode, and terminal animations

### DIFF
--- a/lib/git-harvest
+++ b/lib/git-harvest
@@ -3,6 +3,9 @@ set -euo pipefail
 
 VERSION="0.1.7" # x-release-please-version
 
+# アニメーション中の中断でカーソルが非表示のままにならないよう、EXIT で復元
+trap 'printf "\033[?25h" 2>/dev/null' EXIT
+
 # カラー出力の設定（非TTY / NO_COLOR 環境では無効化）
 USE_COLOR=false
 if [ -t 1 ] && [ -z "${NO_COLOR:-}" ]; then
@@ -128,10 +131,6 @@ sparkle_animate() {
   printf '\033[?25h'
 }
 
-# カウンタ
-WORKTREE_COUNT=0
-BRANCH_COUNT=0
-
 DRY_RUN=false
 
 case "${1:-}" in
@@ -212,12 +211,17 @@ cleanup_worktrees() {
         else
           printf "    [DELETED] %s\n" "$wt"
         fi
-        WORKTREE_COUNT=$((WORKTREE_COUNT + 1))
       fi
     fi
   done < <(git worktree list --porcelain | grep --color=never '^worktree ' | sed 's/^worktree //')
   # 既に存在しない worktree の管理情報を削除
   if [ "$DRY_RUN" = false ]; then git worktree prune; fi
+}
+
+# ブランチが worktree にチェックアウトされているかチェックする
+is_checked_out_in_worktree() {
+  local branch="$1"
+  git worktree list --porcelain | grep -q "^branch refs/heads/${branch}$"
 }
 
 # マージ済みローカルブランチを削除する
@@ -229,6 +233,8 @@ cleanup_branches() {
   while read -r branch; do
     [ -z "$branch" ] && continue
     [ "$branch" = "$base" ] && continue
+    # dry-run: worktree にチェックアウト中のブランチは削除できないのでスキップ
+    if [ "$DRY_RUN" = true ] && is_checked_out_in_worktree "$branch"; then continue; fi
     if { [ "$DRY_RUN" = true ] && git rev-parse --verify "$branch" >/dev/null 2>&1; } || { [ "$DRY_RUN" = false ] && git branch -D "$branch" >/dev/null 2>&1; }; then
       if [ "$found" = false ]; then
         printf "\n  Branches\n"
@@ -239,7 +245,6 @@ cleanup_branches() {
       else
         printf "  [DELETED] %s\n" "$branch"
       fi
-      BRANCH_COUNT=$((BRANCH_COUNT + 1))
     fi
   done <<<"$merged_branches"
   # リモートで削除済みの追跡ブランチを整理

--- a/lib/git-harvest.test.ts
+++ b/lib/git-harvest.test.ts
@@ -366,7 +366,10 @@ describe('combined scenarios', () => {
     expect(worktrees(repo).length).toBeGreaterThan(1);
     // 出力にはサマリーが表示される
     expect(output).toContain('Dry run mode');
-    expect(output).toContain('[WILL DELETE] dry-run-branch');
+    expect(output).toContain('[WILL DELETE]');
+    expect(output).toContain('dry-run-wt-dir');
+    // worktree にチェックアウト中のブランチは削除できないので表示されない
+    expect(output).not.toContain('[WILL DELETE] dry-run-branch');
     expect(output).toContain('Harvested!');
 
     // cleanup
@@ -404,8 +407,8 @@ describe('combined scenarios', () => {
     const output = run(repo, '--dry-run');
     // dirty な worktree は Worktrees セクションに表示されない
     expect(output).not.toContain(`[WILL DELETE] ${wtDir}`);
-    // ブランチは表示される（ブランチ自体は削除可能）
-    expect(output).toContain('[WILL DELETE] drywt-dirty');
+    // worktree にチェックアウト中のブランチも削除できないので表示されない
+    expect(output).not.toContain('[WILL DELETE] drywt-dirty');
 
     // cleanup
     git(repo, `worktree remove --force ${wtDir}`);


### PR DESCRIPTION
## 概要

クリーンアップ実行後の視覚的フィードバックを追加し、ユーザー体験を改善。

- **サマリー表示**: セクションヘッダー（Worktrees / Branches）+ ステータスタグ（`[DELETED]` / `[WILL DELETE]`）で削除結果を一覧表示
- **dry-run モード** (`-n` / `--dry-run`): 実際に削除せずにプレビュー。メインワーキングツリーや未コミット変更のある worktree は正しくスキップ
- **ターミナルアニメーション**: 開始時にキラキラ（緑ベース明度変動）、完了時にレインボー（HSL hue 回転）のアニメーション。非TTY / `NO_COLOR` 環境では自動無効化
- **出力の整理**: `git branch -D` 等の重複メッセージを抑制し、スクリプト独自のフォーマットに統一

## テスト

- dry-run テスト3件追加（削除されないこと、メイン worktree スキップ、dirty worktree スキップ）
- 既存テストのアサーションを新フォーマットに更新
- `NO_COLOR=1` 環境変数で ANSI エスケープ無効化してテスト実行

```bash
bun test
```