### PR TITLE
fix: add issues write permission to release-please workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,6 +19,7 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: write
+      issues: write
       pull-requests: write
 
     outputs:


### PR DESCRIPTION
## Summary
release-please ワークフローに `issues: write` パーミッションを追加。

## 背景
[Actions run #23703808511](https://github.com/nozomiishii/git-harvest/actions/runs/23703808511) で release-please が PR #33 作成後のラベル付与（`autorelease: pending`）に失敗。

```
release-please failed: Validation Failed: {"resource":"Label","code":"unprocessable","field":"data","message":"Could not resolve to a node with the global id of 'PR_kwDORxbUUM7OWqFc'."}
```

## 原因
GitHub のラベル API は Issues エンドポイント（`POST /repos/{owner}/{repo}/issues/{issue_number}/labels`）を使用するため、`issues: write` パーミッションが必要。[公式ドキュメント](https://github.com/googleapis/release-please-action#workflow-permissions)でも推奨されているが、現行ワークフローに含まれていなかった。

関連 Issue: [googleapis/release-please-action#1074](https://github.com/googleapis/release-please-action/issues/1074)

## 変更内容
- `release-please` ジョブのパーミッションに `issues: write` を追加

## Test plan
- [ ] PR マージ後、次回の release-please 実行でラベルが正常に付与されることを確認