### PR TITLE
fix: align branch output indentation with worktree section

### DIFF
--- a/lib/git-harvest
+++ b/lib/git-harvest
@@ -248,7 +248,7 @@ cleanup_branches() {
     fi
   done <<<"$merged_branches"
   # リモートで削除済みの追跡ブランチを整理
-  if [ "$DRY_RUN" = false ]; then git fetch --prune || true; fi
+  if [ "$DRY_RUN" = false ]; then git fetch --prune >/dev/null 2>&1 || true; fi
 }
 
 main() {


### PR DESCRIPTION
## Summary
- Branches セクションの出力インデントを Worktrees セクションと統一（2スペース → 4スペース）

## Test plan
- [x] `bun test` 全テスト通過
- [ ] `git harvest` を実行して Worktrees と Branches のインデントが揃っていることを確認