### PR TITLE
fix: skip branches with no unique commits in merge detection

### DIFF
--- a/lib/git-harvest
+++ b/lib/git-harvest
@@ -265,10 +265,21 @@ main() {
   # デフォルトブランチにマージ済みのローカルブランチ一覧を取得
   # git branch --merged は squash merge を検出できないため、
   # commit-tree で仮想 squash コミットを作成し git cherry で比較する
+  # base の first-parent 上のコミット一覧（独自コミットなしブランチの判定に使用）
+  local first_parent_commits
+  first_parent_commits=$(git rev-list --first-parent "$base" 2>/dev/null) || true
+
   local merged_branches
   merged_branches=$(
     while read -r branch; do
       [ "$branch" = "$base" ] && continue
+      # 独自コミットがないブランチはスキップ（作成直後でまだ作業していないブランチ）
+      # ブランチ HEAD が base の first-parent 上にある場合、独自の作業がないと判断
+      local branch_head
+      branch_head=$(git rev-parse "$branch" 2>/dev/null) || continue
+      if echo "$first_parent_commits" | grep -q "^${branch_head}$"; then
+        continue
+      fi
       # 通常マージ: ブランチが base の祖先であれば完全マージ済み
       if git merge-base --is-ancestor "$branch" "$base" 2>/dev/null; then
         echo "$branch"

--- a/lib/git-harvest.test.ts
+++ b/lib/git-harvest.test.ts
@@ -186,6 +186,27 @@ describe('merge detection', () => {
     expect(output).toContain('Nothing to harvest. All clean!');
   });
 
+  // 独自コミットなしのブランチは保持（作成直後の worktree 用ブランチ等）
+  test('preserves branches with no unique commits', () => {
+    git(repo, 'checkout -b no-commits-yet');
+    git(repo, 'checkout main');
+
+    run(repo);
+    expect(branches(repo)).toContain('no-commits-yet');
+  });
+
+  // main より古いコミットを指す独自コミットなしブランチも保持
+  test('preserves branches pointing to older commits with no unique work', () => {
+    git(repo, 'checkout -b old-branch');
+    git(repo, 'checkout main');
+    // main を先に進める
+    commitFile(repo, 'advance.txt', 'advance main');
+    git(repo, 'push');
+
+    run(repo);
+    expect(branches(repo)).toContain('old-branch');
+  });
+
   // 孤立ブランチはスキップ
   test('skips orphan branches without common ancestor', () => {
     git(repo, 'checkout --orphan isolated');
@@ -245,6 +266,19 @@ describe('worktree cleanup', () => {
 
     run(repo);
     expect(branches(repo)).toContain('wt-unmerged');
+    expect(worktrees(repo).length).toBeGreaterThan(1);
+
+    // cleanup
+    git(repo, `worktree remove ${wtDir}`);
+  });
+
+  // 独自コミットなしの worktree は保持
+  test('preserves worktrees for branches with no unique commits', () => {
+    const wtDir = join(repo, '..', 'wt-no-commits-dir');
+    git(repo, `worktree add -b wt-no-commits ${wtDir}`);
+
+    run(repo);
+    expect(branches(repo)).toContain('wt-no-commits');
     expect(worktrees(repo).length).toBeGreaterThan(1);
 
     // cleanup


### PR DESCRIPTION
## Summary

- 独自コミットのないブランチ（worktree 作成直後など）が `git merge-base --is-ancestor` で「マージ済み」と誤判定され、worktree ごと削除されるバグを修正
- デフォルトブランチの first-parent コミット一覧を事前取得し、ブランチ HEAD がその上にある場合はスキップするガードを追加
- 3つのテストケースを追加（独自コミットなしブランチ保持、main より古いポインタ保持、独自コミットなし worktree 保持）

## 原因

1. `git merge-base --is-ancestor` は、ブランチが main から分岐しただけで独自コミットがない場合も `true` を返す
2. 最初の修正で `git rev-list | grep -q` パイプを使用したが、`set -o pipefail` 環境下で `grep -q` の早期終了が SIGPIPE (exit 141) を引き起こし、条件分岐が機能しなかった

## Test plan

- [x] `bun test` 全 25 テストパス
- [x] 実リポジトリでの `--dry-run` で独自コミットなし worktree が削除対象から除外されることを確認
- [ ] 実際に `git-harvest` を実行して、マージ済みブランチは削除されつつ未使用 worktree が保持されることを確認