### PR TITLE
fix: harden worktree and branch deletion safety checks

### DIFF
--- a/lib/git-harvest
+++ b/lib/git-harvest
@@ -185,6 +185,7 @@ can_remove_worktree() {
   if [ "$wt" = "$main_wt" ]; then return 1; fi
   # 未コミットの変更がある場合は削除不可
   if ! git -C "$wt" diff --quiet HEAD 2>/dev/null; then return 1; fi
+  if ! git -C "$wt" diff --quiet --cached 2>/dev/null; then return 1; fi
   if [ -n "$(git -C "$wt" ls-files --others --exclude-standard 2>/dev/null)" ]; then return 1; fi
   return 0
 }
@@ -200,8 +201,8 @@ cleanup_worktrees() {
     # その worktree が指しているブランチ名を取得
     branch=$(git -C "$wt" rev-parse --abbrev-ref HEAD 2>/dev/null) || continue
     [ "$branch" = "$base" ] && continue
-    if echo "$merged_branches" | grep -qw "$branch"; then
-      if { [ "$DRY_RUN" = true ] && can_remove_worktree "$wt"; } || { [ "$DRY_RUN" = false ] && git worktree remove "$wt" 2>/dev/null; }; then
+    if echo "$merged_branches" | grep -qxF "$branch"; then
+      if { [ "$DRY_RUN" = true ] && can_remove_worktree "$wt"; } || { [ "$DRY_RUN" = false ] && git worktree remove "$wt"; }; then
         if [ "$found" = false ]; then
           printf "\n  Worktrees\n"
           found=true
@@ -290,7 +291,9 @@ main() {
       merge_base=$(git merge-base "$base" "$branch" 2>/dev/null) || continue
       local squash_commit
       squash_commit=$(git commit-tree "$branch^{tree}" -p "$merge_base" -m "_" 2>/dev/null) || continue
-      if [ "$(git cherry "$base" "$squash_commit" 2>/dev/null | grep -c '^+')" -eq 0 ]; then
+      local cherry_out
+      cherry_out=$(git cherry "$base" "$squash_commit" 2>/dev/null) || continue
+      if [ -n "$cherry_out" ] && [ "$(echo "$cherry_out" | grep -c '^+')" -eq 0 ]; then
         echo "$branch"
       fi
     done < <(git branch | sed 's/^[*+ ]*//')

--- a/lib/git-harvest.test.ts
+++ b/lib/git-harvest.test.ts
@@ -410,6 +410,56 @@ describe('combined scenarios', () => {
     git(repo, `worktree remove ${wtDir}`);
   });
 
+  // ブランチ名がマージ済みブランチのプレフィックスでも誤マッチしない
+  test('does not delete worktree whose branch name is a prefix of a merged branch', () => {
+    // feature-login をマージ済みにする
+    git(repo, 'checkout -b feature-login');
+    commitFile(repo, 'login.txt', 'login');
+    git(repo, 'checkout main');
+    git(repo, 'merge --squash feature-login');
+    git(repo, 'commit -m "squash feature-login"');
+    git(repo, 'push');
+
+    // feature は未マージのまま worktree を作成
+    git(repo, 'checkout -b feature');
+    commitFile(repo, 'feature.txt', 'feature work');
+    git(repo, 'checkout main');
+
+    const wtDir = join(repo, '..', 'wt-feature-dir');
+    git(repo, `worktree add ${wtDir} feature`);
+
+    run(repo);
+    // feature-login は削除されるが、feature の worktree とブランチは残る
+    expect(branches(repo)).not.toContain('feature-login');
+    expect(branches(repo)).toContain('feature');
+    expect(worktrees(repo).length).toBeGreaterThan(1);
+
+    // cleanup
+    git(repo, `worktree remove ${wtDir}`);
+  });
+
+  // dry-run でステージ済み変更のある worktree は表示しない
+  test('dry-run skips worktrees with staged-only changes', () => {
+    git(repo, 'checkout -b drywt-staged');
+    commitFile(repo, 'staged-base.txt', 'base');
+    git(repo, 'checkout main');
+    git(repo, 'merge --squash drywt-staged');
+    git(repo, 'commit -m "squash staged"');
+    git(repo, 'push');
+
+    const wtDir = join(repo, '..', 'drywt-staged-dir');
+    git(repo, `worktree add ${wtDir} drywt-staged`);
+    // worktree でファイルをステージだけして、コミットはしない
+    writeFileSync(join(wtDir, 'staged-only.txt'), 'staged\n');
+    git(wtDir, 'add staged-only.txt');
+
+    const output = run(repo, '--dry-run');
+    expect(output).not.toContain(`[WILL DELETE] ${wtDir}`);
+
+    // cleanup
+    git(repo, `worktree remove --force ${wtDir}`);
+  });
+
   // dry-run でメインワーキングツリーは表示しない
   test('dry-run skips main working tree', () => {
     git(repo, 'checkout -b drywt-main-check');


### PR DESCRIPTION
## Summary

#41 のフォローアップ。削除ロジック全体をレビューし、4つの問題を修正。

- **`grep -qw` → `grep -qxF`**: ブランチ名の部分一致による誤削除を防止。`grep -qw` はワード境界でマッチするため、`feature` が `feature-login` にマッチし、未マージ worktree が削除される可能性があった
- **`git cherry` 失敗時の偽陽性防止**: `git cherry` が失敗すると stdout が空 → `grep -c '^+'` が 0 → 未マージブランチが「マージ済み」と誤判定されていた。出力を変数に受けてから空チェックを追加
- **`can_remove_worktree` の staged 変更チェック追加**: `git diff --cached` でステージ済み変更も検出するようにし、dry-run の表示精度を向上
- **`git worktree remove` の stderr 抑制を廃止**: 削除失敗時のエラーメッセージを表示するようにし、デバッグ性を向上

## Test plan

- [x] `bun test` 全 27 テストパス（2テスト追加）
- [x] プレフィックス誤マッチのテスト: `feature-login` がマージ済みでも `feature` の worktree は保持される
- [x] staged 変更のテスト: ステージ済みファイルがある worktree は dry-run で削除対象にならない