### PR TITLE
feat: show status for all worktrees and branches

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -97,6 +97,31 @@ post-merge:
 4. マージ済みブランチを削除
 5. リモートで削除済みの追跡ブランチを整理（`git fetch --prune`）
 
+### ステータス表示
+
+git-harvest は全ての worktree・ブランチの状態を表示します。
+
+#### Worktree
+
+| 状態 | 表示 | 説明 | 挙動 |
+|---|---|---|---|
+| マージ済み + 変更なし | `[DELETED]` / `[WILL DELETE]` | 収穫対象 | 削除 |
+| マージ済み + 未コミット変更あり | `[GROWING] (uncommitted changes)` | 未保存の作業があるためスキップ | 残す |
+| 未マージ | `[GROWING] (not merged)` | まだマージされていない | 残す |
+| 独自コミットなし | `[GROWING] (no unique commits)` | 作成直後でまだ作業が始まっていない | 残す |
+| メインワーキングツリー | *(表示なし)* | 常に除外 | 残す |
+| デフォルトブランチ | *(表示なし)* | 常に除外 | 残す |
+
+#### ブランチ
+
+| 状態 | 表示 | 説明 | 挙動 |
+|---|---|---|---|
+| マージ済み + 削除可能 | `[DELETED]` / `[WILL DELETE]` | 収穫対象 | 削除 |
+| マージ済み + チェックアウト中 | `[GROWING] (currently checked out)` | 現在使用中のためスキップ | 残す |
+| 未マージ | `[GROWING] (not merged)` | まだマージされていない | 残す |
+| 独自コミットなし | `[GROWING] (no unique commits)` | 作成直後でまだ作業が始まっていない | 残す |
+| デフォルトブランチ | *(表示なし)* | 常に除外 | 残す |
+
 ### Squash merge の検出方法
 
 `git commit-tree` で仮想 squash コミットを作成し、`git cherry` でデフォルトブランチに含まれているかを判定します。`git branch --merged` では検出できない squash merge を正しく検出できます。

--- a/README.md
+++ b/README.md
@@ -97,6 +97,31 @@ post-merge:
 4. Deletes the merged branches
 5. Prunes stale remote-tracking references (`git fetch --prune`)
 
+### Status display
+
+git-harvest shows the status of all worktrees and branches.
+
+#### Worktrees
+
+| State | Display | Description | Action |
+|---|---|---|---|
+| Merged + clean | `[DELETED]` / `[WILL DELETE]` | Ready to harvest | Remove |
+| Merged + uncommitted changes | `[GROWING] (uncommitted changes)` | Has unsaved work, skipped | Keep |
+| Not merged | `[GROWING] (not merged)` | Not yet merged | Keep |
+| No unique commits | `[GROWING] (no unique commits)` | Just created, no work started yet | Keep |
+| Main working tree | *(not shown)* | Always excluded | Keep |
+| Default branch | *(not shown)* | Always excluded | Keep |
+
+#### Branches
+
+| State | Display | Description | Action |
+|---|---|---|---|
+| Merged + deletable | `[DELETED]` / `[WILL DELETE]` | Ready to harvest | Remove |
+| Merged + currently checked out | `[GROWING] (currently checked out)` | Currently in use, skipped | Keep |
+| Not merged | `[GROWING] (not merged)` | Not yet merged | Keep |
+| No unique commits | `[GROWING] (no unique commits)` | Just created, no work started yet | Keep |
+| Default branch | *(not shown)* | Always excluded | Keep |
+
 ### Squash merge detection
 
 Uses `git commit-tree` to create a virtual squash commit and `git cherry` to check if the result is already included in the default branch. This correctly detects squash merges, which `git branch --merged` cannot.

--- a/lib/git-harvest
+++ b/lib/git-harvest
@@ -296,43 +296,57 @@ default_branch() {
   echo "$branch"
 }
 
-# worktree が削除可能かチェックする
-can_remove_worktree() {
+# worktree に未コミットの変更があるかチェックする (0=あり, 1=なし)
+has_uncommitted_changes() {
   local wt="$1"
-  # メインワーキングツリーは削除不可
-  local main_wt
-  main_wt=$(git worktree list --porcelain | grep -m1 '^worktree ' | sed 's/^worktree //')
-  if [ "$wt" = "$main_wt" ]; then return 1; fi
-  # 未コミットの変更がある場合は削除不可
-  if ! git -C "$wt" diff --quiet HEAD 2>/dev/null; then return 1; fi
-  if ! git -C "$wt" diff --quiet --cached 2>/dev/null; then return 1; fi
-  if [ -n "$(git -C "$wt" ls-files --others --exclude-standard 2>/dev/null)" ]; then return 1; fi
-  return 0
+  if ! git -C "$wt" diff --quiet HEAD 2>/dev/null; then return 0; fi
+  if ! git -C "$wt" diff --quiet --cached 2>/dev/null; then return 0; fi
+  if [ -n "$(git -C "$wt" ls-files --others --exclude-standard 2>/dev/null)" ]; then return 0; fi
+  return 1
 }
 
-# マージ済みブランチに紐づく worktree を削除する
+# worktree の状態を表示・削除する (DELETED_COUNT をインクリメント)
 cleanup_worktrees() {
   local base="$1"
   local merged_branches="$2"
+  local no_unique_branches="$3"
   local found=false
+
+  # メインワーキングツリーのパスを取得
+  local main_wt
+  main_wt=$(git worktree list --porcelain | grep --color=never -m1 '^worktree ' | sed 's/^worktree //')
 
   # 全 worktree のパスを取得してループ
   while read -r wt; do
+    # メインワーキングツリーは表示しない
+    [ "$wt" = "$main_wt" ] && continue
     # その worktree が指しているブランチ名を取得
+    local branch
     branch=$(git -C "$wt" rev-parse --abbrev-ref HEAD 2>/dev/null) || continue
+    # デフォルトブランチの worktree は表示しない
     [ "$branch" = "$base" ] && continue
+
+    if [ "$found" = false ]; then
+      printf "\n  Worktrees\n"
+      found=true
+    fi
+
     if echo "$merged_branches" | grep -qxF "$branch"; then
-      if { [ "$DRY_RUN" = true ] && can_remove_worktree "$wt"; } || { [ "$DRY_RUN" = false ] && git worktree remove "$wt"; }; then
-        if [ "$found" = false ]; then
-          printf "\n  Worktrees\n"
-          found=true
-        fi
-        if [ "$DRY_RUN" = true ]; then
-          printf "    [WILL DELETE] %s\n" "$wt"
-        else
-          printf "    [DELETED] %s\n" "$wt"
-        fi
+      # マージ済み: 未コミット変更があるかチェック
+      if has_uncommitted_changes "$wt"; then
+        printf "    [GROWING]      %s (uncommitted changes)\n" "$wt"
+      elif [ "$DRY_RUN" = true ]; then
+        printf "    [WILL DELETE]  %s\n" "$wt"
+        DELETED_COUNT=$((DELETED_COUNT + 1))
+      else
+        git worktree remove "$wt"
+        printf "    [DELETED]      %s\n" "$wt"
+        DELETED_COUNT=$((DELETED_COUNT + 1))
       fi
+    elif echo "$no_unique_branches" | grep -qxF "$branch"; then
+      printf "    [GROWING]      %s (no unique commits)\n" "$wt"
+    else
+      printf "    [GROWING]      %s (not merged)\n" "$wt"
     fi
   done < <(git worktree list --porcelain | grep --color=never '^worktree ' | sed 's/^worktree //')
   # 既に存在しない worktree の管理情報を削除
@@ -345,29 +359,48 @@ is_checked_out_in_worktree() {
   git worktree list --porcelain | grep -q "^branch refs/heads/${branch}$"
 }
 
-# マージ済みローカルブランチを削除する
+# ブランチが現在の HEAD かチェックする
+is_current_head() {
+  local branch="$1"
+  local current
+  current=$(git symbolic-ref --short HEAD 2>/dev/null) || return 1
+  [ "$branch" = "$current" ]
+}
+
+# ブランチの状態を表示・削除する (DELETED_COUNT をインクリメント)
 cleanup_branches() {
   local base="$1"
   local merged_branches="$2"
+  local no_unique_branches="$3"
   local found=false
 
   while read -r branch; do
     [ -z "$branch" ] && continue
     [ "$branch" = "$base" ] && continue
-    # dry-run: worktree にチェックアウト中のブランチは削除できないのでスキップ
-    if [ "$DRY_RUN" = true ] && is_checked_out_in_worktree "$branch"; then continue; fi
-    if { [ "$DRY_RUN" = true ] && git rev-parse --verify "$branch" >/dev/null 2>&1; } || { [ "$DRY_RUN" = false ] && git branch -D "$branch" >/dev/null 2>&1; }; then
-      if [ "$found" = false ]; then
-        printf "\n  Branches\n"
-        found=true
-      fi
-      if [ "$DRY_RUN" = true ]; then
-        printf "    [WILL DELETE] %s\n" "$branch"
-      else
-        printf "    [DELETED] %s\n" "$branch"
-      fi
+
+    if [ "$found" = false ]; then
+      printf "\n  Branches\n"
+      found=true
     fi
-  done <<<"$merged_branches"
+
+    if echo "$merged_branches" | grep -qxF "$branch"; then
+      # マージ済み: チェックアウト中かチェック
+      if is_current_head "$branch" || is_checked_out_in_worktree "$branch"; then
+        printf "    [GROWING]      %s (currently checked out)\n" "$branch"
+      elif [ "$DRY_RUN" = true ]; then
+        printf "    [WILL DELETE]  %s\n" "$branch"
+        DELETED_COUNT=$((DELETED_COUNT + 1))
+      else
+        git branch -D "$branch" >/dev/null 2>&1
+        printf "    [DELETED]      %s\n" "$branch"
+        DELETED_COUNT=$((DELETED_COUNT + 1))
+      fi
+    elif echo "$no_unique_branches" | grep -qxF "$branch"; then
+      printf "    [GROWING]      %s (no unique commits)\n" "$branch"
+    else
+      printf "    [GROWING]      %s (not merged)\n" "$branch"
+    fi
+  done < <(git branch | sed 's/^[*+ ]*//')
   # リモートで削除済みの追跡ブランチを整理
   if [ "$DRY_RUN" = false ]; then git fetch --prune >/dev/null 2>&1 || true; fi
 }
@@ -394,45 +427,67 @@ main() {
   local first_parent_commits
   first_parent_commits=$(git rev-list --first-parent "$base" 2>/dev/null) || true
 
-  local merged_branches
-  merged_branches=$(
-    while read -r branch; do
-      [ "$branch" = "$base" ] && continue
-      # 独自コミットがないブランチはスキップ（作成直後でまだ作業していないブランチ）
-      # ブランチ HEAD が base の first-parent 上にある場合、独自の作業がないと判断
-      local branch_head
-      branch_head=$(git rev-parse "$branch" 2>/dev/null) || continue
-      if echo "$first_parent_commits" | grep -q "^${branch_head}$"; then
-        continue
-      fi
-      # 通常マージ: ブランチが base の祖先であれば完全マージ済み
-      if git merge-base --is-ancestor "$branch" "$base" 2>/dev/null; then
-        echo "$branch"
-        continue
-      fi
-      # squash マージ: commit-tree で仮想 squash コミットを作成し git cherry で比較
-      local merge_base
-      merge_base=$(git merge-base "$base" "$branch" 2>/dev/null) || continue
-      local squash_commit
-      squash_commit=$(git commit-tree "$branch^{tree}" -p "$merge_base" -m "_" 2>/dev/null) || continue
-      local cherry_out
-      cherry_out=$(git cherry "$base" "$squash_commit" 2>/dev/null) || continue
-      if [ -n "$cherry_out" ] && [ "$(echo "$cherry_out" | grep -c '^+')" -eq 0 ]; then
-        echo "$branch"
-      fi
-    done < <(git branch | sed 's/^[*+ ]*//')
-  )
+  local all_branches
+  all_branches=$(git branch | sed 's/^[*+ ]*//')
 
-  if [ -z "$merged_branches" ]; then
+  local merged_branches=""
+  local no_unique_branches=""
+
+  while read -r branch; do
+    [ "$branch" = "$base" ] && continue
+    # 独自コミットがないブランチ（作成直後でまだ作業していないブランチ）
+    # ブランチ HEAD が base の first-parent 上にある場合、独自の作業がないと判断
+    local branch_head
+    branch_head=$(git rev-parse "$branch" 2>/dev/null) || continue
+    if echo "$first_parent_commits" | grep -q "^${branch_head}$"; then
+      no_unique_branches="${no_unique_branches:+$no_unique_branches
+}$branch"
+      continue
+    fi
+    # 通常マージ: ブランチが base の祖先であれば完全マージ済み
+    if git merge-base --is-ancestor "$branch" "$base" 2>/dev/null; then
+      merged_branches="${merged_branches:+$merged_branches
+}$branch"
+      continue
+    fi
+    # squash マージ: commit-tree で仮想 squash コミットを作成し git cherry で比較
+    local merge_base
+    merge_base=$(git merge-base "$base" "$branch" 2>/dev/null) || continue
+    local squash_commit
+    squash_commit=$(git commit-tree "$branch^{tree}" -p "$merge_base" -m "_" 2>/dev/null) || continue
+    local cherry_out
+    cherry_out=$(git cherry "$base" "$squash_commit" 2>/dev/null) || continue
+    if [ -n "$cherry_out" ] && [ "$(echo "$cherry_out" | grep -c '^+')" -eq 0 ]; then
+      merged_branches="${merged_branches:+$merged_branches
+}$branch"
+    fi
+  done <<<"$all_branches"
+
+  # デフォルトブランチのみ（他にブランチも linked worktree もない）場合
+  local linked_wt_count
+  linked_wt_count=$(git worktree list --porcelain | grep -c '^worktree ' || true)
+  linked_wt_count=$((linked_wt_count - 1)) # メインワーキングツリーを除外
+
+  local other_branch_count=0
+  while read -r b; do
+    [ -n "$b" ] && [ "$b" != "$base" ] && other_branch_count=$((other_branch_count + 1))
+  done <<<"$all_branches"
+
+  if [ "$other_branch_count" -eq 0 ] && [ "$linked_wt_count" -eq 0 ]; then
     printf "  Nothing to harvest. All clean!\n\n"
   else
     # worktree が参照中のブランチは削除できないため、worktree を先に削除する
-    cleanup_worktrees "$base" "$merged_branches"
-    cleanup_branches "$base" "$merged_branches"
+    DELETED_COUNT=0
+    cleanup_worktrees "$base" "$merged_branches" "$no_unique_branches"
+    cleanup_branches "$base" "$merged_branches" "$no_unique_branches"
 
     # サマリー表示
     printf "\n\n"
-    rainbow_animate "Harvested!"
+    if [ "$DELETED_COUNT" -gt 0 ]; then
+      rainbow_animate "Harvested!"
+    else
+      printf "  Nothing to harvest. All growing!"
+    fi
     printf '\n\n\n'
   fi
 

--- a/lib/git-harvest.test.ts
+++ b/lib/git-harvest.test.ts
@@ -153,7 +153,8 @@ describe('merge detection', () => {
     const output = run(repo);
     expect(branches(repo)).not.toContain('feature-regular');
     expect(branches(repo)).toContain('main');
-    expect(output).toContain('[DELETED] feature-regular');
+    expect(output).toContain('[DELETED]');
+    expect(output).toContain('feature-regular');
     expect(output).toContain('Harvested!');
   });
 
@@ -170,18 +171,22 @@ describe('merge detection', () => {
     const output = run(repo);
     expect(branches(repo)).not.toContain('feature-squash');
     expect(branches(repo)).toContain('main');
-    expect(output).toContain('[DELETED] feature-squash');
+    expect(output).toContain('[DELETED]');
+    expect(output).toContain('feature-squash');
     expect(output).toContain('Harvested!');
   });
 
-  // 未マージは保持
-  test('preserves unmerged branches', () => {
+  // 未マージは保持し [GROWING] (not merged) を表示
+  test('preserves unmerged branches and shows GROWING status', () => {
     git(repo, 'checkout -b feature-wip');
     commitFile(repo, 'wip.txt', 'wip');
     git(repo, 'checkout main');
 
-    run(repo);
+    const output = run(repo);
     expect(branches(repo)).toContain('feature-wip');
+    expect(output).toContain('[GROWING]');
+    expect(output).toContain('feature-wip');
+    expect(output).toContain('(not merged)');
   });
 
   // マージ済みなし → Nothing to harvest メッセージ
@@ -191,13 +196,16 @@ describe('merge detection', () => {
     expect(output).toContain('Nothing to harvest. All clean!');
   });
 
-  // 独自コミットなしのブランチは保持（作成直後の worktree 用ブランチ等）
-  test('preserves branches with no unique commits', () => {
+  // 独自コミットなしのブランチは保持し [GROWING] (no unique commits) を表示
+  test('preserves branches with no unique commits and shows GROWING status', () => {
     git(repo, 'checkout -b no-commits-yet');
     git(repo, 'checkout main');
 
-    run(repo);
+    const output = run(repo);
     expect(branches(repo)).toContain('no-commits-yet');
+    expect(output).toContain('[GROWING]');
+    expect(output).toContain('no-commits-yet');
+    expect(output).toContain('(no unique commits)');
   });
 
   // main より古いコミットを指す独自コミットなしブランチも保持
@@ -260,8 +268,8 @@ describe('worktree cleanup', () => {
     git(repo, `worktree remove ${wtDir}`);
   });
 
-  // 未マージ worktree は保持
-  test('preserves worktrees for unmerged branches', () => {
+  // 未マージ worktree は保持し [GROWING] (not merged) を表示
+  test('preserves worktrees for unmerged branches and shows GROWING status', () => {
     git(repo, 'checkout -b wt-unmerged');
     commitFile(repo, 'wt-unmerged.txt', 'unmerged work');
     git(repo, 'checkout main');
@@ -269,22 +277,26 @@ describe('worktree cleanup', () => {
     const wtDir = join(repo, '..', 'wt-unmerged-dir');
     git(repo, `worktree add ${wtDir} wt-unmerged`);
 
-    run(repo);
+    const output = run(repo);
     expect(branches(repo)).toContain('wt-unmerged');
     expect(worktrees(repo).length).toBeGreaterThan(1);
+    expect(output).toContain('[GROWING]');
+    expect(output).toContain('(not merged)');
 
     // cleanup
     git(repo, `worktree remove ${wtDir}`);
   });
 
-  // 独自コミットなしの worktree は保持
-  test('preserves worktrees for branches with no unique commits', () => {
+  // 独自コミットなしの worktree は保持し [GROWING] (no unique commits) を表示
+  test('preserves worktrees for branches with no unique commits and shows GROWING status', () => {
     const wtDir = join(repo, '..', 'wt-no-commits-dir');
     git(repo, `worktree add -b wt-no-commits ${wtDir}`);
 
-    run(repo);
+    const output = run(repo);
     expect(branches(repo)).toContain('wt-no-commits');
     expect(worktrees(repo).length).toBeGreaterThan(1);
+    expect(output).toContain('[GROWING]');
+    expect(output).toContain('(no unique commits)');
 
     // cleanup
     git(repo, `worktree remove ${wtDir}`);
@@ -407,8 +419,9 @@ describe('combined scenarios', () => {
     expect(output).toContain('Dry run mode');
     expect(output).toContain('[WILL DELETE]');
     expect(output).toContain('dry-run-wt-dir');
-    // worktree にチェックアウト中のブランチは削除できないので表示されない
-    expect(output).not.toContain('[WILL DELETE] dry-run-branch');
+    // worktree にチェックアウト中のブランチは [GROWING] (currently checked out) として表示
+    expect(output).toContain('[GROWING]');
+    expect(output).toContain('(currently checked out)');
     expect(output).toContain('Harvested!');
 
     // cleanup
@@ -443,8 +456,8 @@ describe('combined scenarios', () => {
     git(repo, `worktree remove ${wtDir}`);
   });
 
-  // dry-run でステージ済み変更のある worktree は表示しない
-  test('dry-run skips worktrees with staged-only changes', () => {
+  // dry-run でステージ済み変更のある worktree は [GROWING] (uncommitted changes) を表示
+  test('dry-run shows GROWING for worktrees with staged-only changes', () => {
     git(repo, 'checkout -b drywt-staged');
     commitFile(repo, 'staged-base.txt', 'base');
     git(repo, 'checkout main');
@@ -459,7 +472,9 @@ describe('combined scenarios', () => {
     git(wtDir, 'add staged-only.txt');
 
     const output = run(repo, '--dry-run');
-    expect(output).not.toContain(`[WILL DELETE] ${wtDir}`);
+    expect(output).not.toContain(`[WILL DELETE]`);
+    expect(output).toContain('[GROWING]');
+    expect(output).toContain('(uncommitted changes)');
 
     // cleanup
     git(repo, `worktree remove --force ${wtDir}`);
@@ -479,8 +494,8 @@ describe('combined scenarios', () => {
     expect(output).not.toContain(`[WILL DELETE] ${repo}`);
   });
 
-  // dry-run で未コミット変更のある worktree は表示しない
-  test('dry-run skips dirty worktrees', () => {
+  // dry-run で未コミット変更のある worktree は [GROWING] (uncommitted changes) を表示
+  test('dry-run shows GROWING for dirty worktrees', () => {
     git(repo, 'checkout -b drywt-dirty');
     commitFile(repo, 'dirty-base.txt', 'base');
     git(repo, 'checkout main');
@@ -494,13 +509,72 @@ describe('combined scenarios', () => {
     writeFileSync(join(wtDir, 'uncommitted.txt'), 'dirty\n');
 
     const output = run(repo, '--dry-run');
-    // dirty な worktree は Worktrees セクションに表示されない
-    expect(output).not.toContain(`[WILL DELETE] ${wtDir}`);
-    // worktree にチェックアウト中のブランチも削除できないので表示されない
-    expect(output).not.toContain('[WILL DELETE] drywt-dirty');
+    // dirty な worktree は [GROWING] として表示
+    expect(output).toContain('[GROWING]');
+    expect(output).toContain('(uncommitted changes)');
+    // worktree にチェックアウト中のブランチも削除できない
+    expect(output).toContain('(currently checked out)');
 
     // cleanup
     git(repo, `worktree remove --force ${wtDir}`);
+  });
+
+  // マージ済みブランチをチェックアウト中に実行 → [GROWING] (currently checked out) を表示
+  test('shows GROWING for merged branch that is currently checked out', () => {
+    git(repo, 'checkout -b checked-out-merged');
+    commitFile(repo, 'co.txt', 'checked out work');
+    git(repo, 'checkout main');
+    git(repo, 'merge --squash checked-out-merged');
+    git(repo, 'commit -m "squash co"');
+    git(repo, 'push');
+
+    // マージ済みブランチに戻って実行
+    git(repo, 'checkout checked-out-merged');
+    const output = run(repo);
+    // ブランチは削除されず [GROWING] (currently checked out) を表示
+    expect(branches(repo)).toContain('checked-out-merged');
+    expect(output).toContain('[GROWING]');
+    expect(output).toContain('checked-out-merged');
+    expect(output).toContain('(currently checked out)');
+    expect(output).not.toContain('[DELETED]');
+  });
+
+  // 実行時: マージ済み + dirty worktree → [GROWING] (uncommitted changes) を表示
+  test('shows GROWING for dirty worktree during actual run', () => {
+    git(repo, 'checkout -b dirty-wt-run');
+    commitFile(repo, 'dirty-run.txt', 'dirty run work');
+    git(repo, 'checkout main');
+    git(repo, 'merge --squash dirty-wt-run');
+    git(repo, 'commit -m "squash dirty-run"');
+    git(repo, 'push');
+
+    const wtDir = join(repo, '..', 'dirty-wt-run-dir');
+    git(repo, `worktree add ${wtDir} dirty-wt-run`);
+    // worktree に未コミットの変更を追加
+    writeFileSync(join(wtDir, 'uncommitted.txt'), 'dirty\n');
+
+    const output = run(repo);
+    // worktree もブランチも残る
+    expect(worktrees(repo).length).toBeGreaterThan(1);
+    expect(branches(repo)).toContain('dirty-wt-run');
+    // [GROWING] (uncommitted changes) が表示される
+    expect(output).toContain('[GROWING]');
+    expect(output).toContain('(uncommitted changes)');
+    expect(output).not.toContain('[DELETED]');
+
+    // cleanup
+    git(repo, `worktree remove --force ${wtDir}`);
+  });
+
+  // 全てのブランチが GROWING の場合 → "Nothing to harvest. All growing!" を表示
+  test('shows "All growing" when nothing is deleted', () => {
+    git(repo, 'checkout -b only-growing');
+    commitFile(repo, 'growing.txt', 'growing work');
+    git(repo, 'checkout main');
+
+    const output = run(repo);
+    expect(output).toContain('Nothing to harvest. All growing!');
+    expect(output).not.toContain('Harvested!');
   });
 
   // exit code 0


### PR DESCRIPTION
## Summary

- 全ての worktree・ブランチに対してステータス（`[DELETED]`/`[WILL DELETE]`/`[GROWING]` + 理由）を表示するように変更
- dry-run と実行時の判定ロジックを統一（`can_remove_worktree` → `has_uncommitted_changes` にリファクタ）
- `grep -m1` に `--color=never` がなくカラーコードでメインワーキングツリーのパス比較が失敗するバグを修正
- README.md / README.ja.md にステータス表示の一覧表を追加

## 変更の背景

- 削除されなかった worktree やブランチの状態が見えなかったため、ユーザーが全体の状況を把握しづらかった
- dry-run 時は `can_remove_worktree` でチェックし、実行時は `git worktree remove` のエラーに依存するという判定ロジックの不統一があった

## Test plan

- [x] `bun test` 全 35 テスト pass（既存 27 + 新規 3 + origin/main の update check 5）
- [ ] `git-harvest --dry-run` で `[WILL DELETE]` と `[GROWING]` が正しく表示されることを確認
- [ ] `git-harvest` で実際に削除後 `[DELETED]` と `[GROWING]` が正しく表示されることを確認