### PR TITLE
fix: move restart instruction to end of install message

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -79,9 +79,6 @@ main() {
   echo "git-harvest was installed successfully!"
   echo "  Binary: $BIN_DIR/git-harvest"
   echo ""
-  echo "Restart your terminal or run:"
-  echo "  source ~/.zshrc"
-  echo ""
   echo "Set up aliases for quicker access."
   echo "You can use both or just the one you prefer:"
   echo ""
@@ -90,6 +87,10 @@ main() {
   echo ""
   echo "  # Git subcommand — run as 'git harvest'"
   echo "  git config --global alias.harvest '!git-harvest'"
+  echo ""
+  echo "Restart your terminal or run:"
+  echo "  source ~/.zshrc"
+  echo ""
 }
 
 main


### PR DESCRIPTION
## 概要
- インストール後のメッセージで「Restart your terminal or run: source ~/.zshrc」をエイリアス設定案内の後（最後）に移動
- エイリアス追加後に一度の `source` で全て反映できる自然な流れに変更

## テストプラン
- [ ] `install.sh` の出力メッセージの順序が正しいことを確認