### PR TITLE
chore: drop CLAUDE.md rules moved to global

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,11 +2,6 @@
 
 このリポジトリで Claude Code (claude.ai/code) が作業する際のガイドラインです。
 
-## 言語
-
-- **応答言語**: プラン説明や返答は常に日本語で行い、コードやコマンド、技術用語はそのまま使用してよい。
-- **PR 本文**: プルリクエストの本文（body）は日本語で記述する。
-
 ## よく使うコマンド
 
 ```bash
@@ -19,8 +14,6 @@ bun install
 
 ## Git・GitHub 運用ルール
 
-- PR のマージは必ずユーザーが手動で行う。AI アシスタントが `gh pr merge` や GitHub API 経由でマージを実行してはならない。
-- PR の作成・更新・push は許可するが、マージの最終判断は常にユーザーに委ねること。
 - PR タイトルは英語 semantic 形式で記述する。
 - ブランチ保護は **GitHub Rulesets のみ**で管理する。従来の Branch Protection Rules は使用しない。
 - Rulesets の bypass_actors は空（誰も bypass 不可）を維持する。


### PR DESCRIPTION
## Summary

workspaces の横断作業で、各 repo の `CLAUDE.md` に重複していた共通ルールをグローバル `~/.claude/CLAUDE.md` に集約中です。本 repo では:

- グローバル化した共通ルールを `CLAUDE.md` から削除

`AGENTS.md` は元々存在しないため、ファイル命名統一は不要です。

## 削除した共通ルール（global 側に移行済み）

- 応答言語は日本語
- PR 本文は日本語
- PR のマージはユーザー手動（AI は `gh pr merge` 禁止）
- PR 作成・更新・push は AI 可、マージ判断のみユーザー

## 残置したルール

- PR タイトル英語 semantic 形式（ツール化で強制するまで repo に残す）
- ブランチ保護 GitHub Rulesets 運用ルール
- テストスタイル・README フォーマット・アーキテクチャ
