### PR TITLE
chore: migrate reusable workflows to v3.0.0

### DIFF
--- a/.github/workflows/_github-actions.yaml
+++ b/.github/workflows/_github-actions.yaml
@@ -12,9 +12,9 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: read
-  pull-requests: read
-  actions: read
+  contents: read  # required by actions/checkout to fetch repository code
+  pull-requests: read  # required by dorny/paths-filter to list PR files via the GitHub API
+  actions: read  # required by gh api referenced_workflows to resolve the zizmor config SHA
 
 jobs:
   github-actions:

--- a/.github/workflows/_github-actions.yaml
+++ b/.github/workflows/_github-actions.yaml
@@ -1,4 +1,4 @@
-name: Lint GitHub Actions workflows
+name: GitHub Actions
 
 on:
   workflow_dispatch:
@@ -14,7 +14,8 @@ concurrency:
 permissions:
   contents: read
   pull-requests: read
+  actions: read
 
 jobs:
-  actionlint:
-    uses: nozomiishii/workflows/.github/workflows/actionlint.yaml@7e6fb98cc189a7b5ef23eee616a04238c5d9a468 # v1.1.1
+  github-actions:
+    uses: nozomiishii/workflows/.github/workflows/github-actions.yaml@4114f39af968607bdcef88b48d29605df89728fd # v3.0.0

--- a/.github/workflows/_pull-request.yaml
+++ b/.github/workflows/_pull-request.yaml
@@ -8,7 +8,7 @@ on:
       - synchronize
 
 permissions:
-  pull-requests: read
+  pull-requests: read  # required by action-semantic-pull-request to read the PR title via the GitHub API
 
 jobs:
   pull-request:

--- a/.github/workflows/_pull-request.yaml
+++ b/.github/workflows/_pull-request.yaml
@@ -12,4 +12,4 @@ permissions:
 
 jobs:
   pull-request:
-    uses: nozomiishii/workflows/.github/workflows/pull-request.yaml@7e6fb98cc189a7b5ef23eee616a04238c5d9a468 # v1.1.1
+    uses: nozomiishii/workflows/.github/workflows/pull-request.yaml@4114f39af968607bdcef88b48d29605df89728fd # v3.0.0

--- a/.github/workflows/_secret-scan.yaml
+++ b/.github/workflows/_secret-scan.yaml
@@ -11,5 +11,5 @@ permissions:
   contents: read
 
 jobs:
-  secretlint:
-    uses: nozomiishii/workflows/.github/workflows/secretlint.yaml@7e6fb98cc189a7b5ef23eee616a04238c5d9a468 # v1.1.1
+  secret-scan:
+    uses: nozomiishii/workflows/.github/workflows/secret-scan.yaml@4114f39af968607bdcef88b48d29605df89728fd # v3.0.0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,8 +24,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
-      contents: write
-      pull-requests: write
+      contents: write  # required by release-please to create git tags and draft GitHub releases
+      pull-requests: write  # required by release-please to open and update the release PR
 
     outputs:
       release_created: ${{ steps.detect.outputs.release_created }}
@@ -51,6 +51,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
@@ -59,14 +60,15 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Run release-please github-release
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO_URL: ${{ github.repository }}
         run: |
           bunx release-please github-release \
-            --repo-url="${{ github.repository }}" \
+            --repo-url="${REPO_URL}" \
             --config-file=.github/.release-please-config.json \
             --manifest-file=.github/.release-please-manifest.json \
             --token="${GITHUB_TOKEN}"
-        env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Detect created release
         id: detect
@@ -89,23 +91,26 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
-      contents: write
+      contents: write  # required by gh release upload/edit to attach assets and publish the draft release
 
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ needs.create-draft-release.outputs.tag_name }}
+          persist-credentials: false
 
       - name: Upload release assets
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release upload "${{ needs.create-draft-release.outputs.tag_name }}" lib/git-harvest
+          TAG_NAME: ${{ needs.create-draft-release.outputs.tag_name }}
+        run: gh release upload "${TAG_NAME}" lib/git-harvest
 
       - name: Publish Release
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release edit "${{ needs.create-draft-release.outputs.tag_name }}" --draft=false
+          TAG_NAME: ${{ needs.create-draft-release.outputs.tag_name }}
+        run: gh release edit "${TAG_NAME}" --draft=false
 
   npm-publish:
     needs: create-draft-release
@@ -113,14 +118,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
-      contents: read
-      id-token: write
+      contents: read  # required by actions/checkout to fetch the tagged release commit
+      id-token: write  # required by npm publish to mint an OIDC token for provenance
 
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ needs.create-draft-release.outputs.tag_name }}
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -140,7 +146,7 @@ jobs:
       group: homebrew-update
       cancel-in-progress: false
     permissions:
-      contents: read
+      contents: read  # required by 1password/load-secrets-action and downstream steps to read repo metadata
 
     steps:
       - name: Load secrets from 1Password
@@ -180,8 +186,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
-      contents: write
-      pull-requests: write
+      contents: write  # required by release-please to push release PR branches
+      pull-requests: write  # required by release-please to open and update the release PR
 
     steps:
       - name: Load secrets from 1Password
@@ -203,6 +209,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
@@ -211,11 +218,12 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Run release-please release-pr
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO_URL: ${{ github.repository }}
         run: |
           bunx release-please release-pr \
-            --repo-url="${{ github.repository }}" \
+            --repo-url="${REPO_URL}" \
             --config-file=.github/.release-please-config.json \
             --manifest-file=.github/.release-please-manifest.json \
             --token="${GITHUB_TOKEN}"
-        env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,6 +15,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# デフォルト権限を無効化し、各ジョブで必要最小限の権限のみ付与する
+permissions: {}
+
 defaults:
   run:
     shell: bash
@@ -23,10 +26,14 @@ jobs:
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read  # required by actions/checkout to fetch repository code and dorny/paths-filter to diff against the base ref
 
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Check for changes
         uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1


### PR DESCRIPTION
## 概要

`nozomiishii/workflows` v3.0.0 リリースに先行して caller 側を移行する。pin は main HEAD の SHA（v3.0.0 release PR merge 直前の状態）を使用。

## 変更内容

- `_actionlint.yaml` → **`_github-actions.yaml`**
  - 呼び先を v2 aggregator `github-actions.yaml`（actionlint + zizmor）に差し替え
  - permissions に `actions: read` 追加（zizmor auditor persona 用）
  - job / workflow 名も v2 に合わせて rename
- `_secretlint.yaml` → **`_secret-scan.yaml`**
  - 呼び先を v2 concept-named `secret-scan.yaml` に差し替え
- `_pull-request.yaml`
  - SHA pin を v3.0.0（未リリース、main HEAD）に bump

## ⚠️ branch protection 更新が必要

この PR を merge する前に、default branch の required status checks を以下に更新:

| 旧 | 新 |
|---|---|
| `actionlint / lint` | `github-actions / required` |
| `secretlint / scan` | `secret-scan / secretlint` |
| `pull-request / validate` | そのまま |

## 関連

- 既存の renovate PR（SHA の単純 bump）は本 PR で代替するので close する
- `nozomiishii/workflows` 側の v3.0.0 release PR は全 caller migration 完了後に merge される予定
