### PR TITLE
chore(workflows): fix zizmor findings in caller workflows

### DIFF
--- a/.github/workflows/_github-actions.yaml
+++ b/.github/workflows/_github-actions.yaml
@@ -12,9 +12,9 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: read
-  pull-requests: read
-  actions: read
+  contents: read  # required by actions/checkout to fetch repository code
+  pull-requests: read  # required by dorny/paths-filter to list PR files via the GitHub API
+  actions: read  # required by gh api referenced_workflows to resolve the zizmor config SHA
 
 jobs:
   github-actions:

--- a/.github/workflows/_pull-request.yaml
+++ b/.github/workflows/_pull-request.yaml
@@ -8,7 +8,7 @@ on:
       - synchronize
 
 permissions:
-  pull-requests: read
+  pull-requests: read  # required by action-semantic-pull-request to read the PR title via the GitHub API
 
 jobs:
   pull-request:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,8 +24,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
-      contents: write
-      pull-requests: write
+      contents: write  # required by release-please to create git tags and draft GitHub releases
+      pull-requests: write  # required by release-please to open and update the release PR
 
     outputs:
       release_created: ${{ steps.detect.outputs.release_created }}
@@ -51,6 +51,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
@@ -59,14 +60,15 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Run release-please github-release
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO_URL: ${{ github.repository }}
         run: |
           bunx release-please github-release \
-            --repo-url="${{ github.repository }}" \
+            --repo-url="${REPO_URL}" \
             --config-file=.github/.release-please-config.json \
             --manifest-file=.github/.release-please-manifest.json \
             --token="${GITHUB_TOKEN}"
-        env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Detect created release
         id: detect
@@ -89,13 +91,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
-      contents: write
+      contents: write  # required by gh release upload/edit to attach assets and publish the draft release
 
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ needs.create-draft-release.outputs.tag_name }}
+          persist-credentials: false
 
       - name: Upload release assets
         env:
@@ -113,14 +116,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
-      contents: read
-      id-token: write
+      contents: read  # required by actions/checkout to fetch the tagged release commit
+      id-token: write  # required by npm publish to mint an OIDC token for provenance
 
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ needs.create-draft-release.outputs.tag_name }}
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -140,7 +144,7 @@ jobs:
       group: homebrew-update
       cancel-in-progress: false
     permissions:
-      contents: read
+      contents: read  # required by 1password/load-secrets-action and downstream steps to read repo metadata
 
     steps:
       - name: Load secrets from 1Password
@@ -180,8 +184,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
-      contents: write
-      pull-requests: write
+      contents: write  # required by release-please to push release PR branches
+      pull-requests: write  # required by release-please to open and update the release PR
 
     steps:
       - name: Load secrets from 1Password
@@ -203,6 +207,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
@@ -211,11 +216,12 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Run release-please release-pr
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO_URL: ${{ github.repository }}
         run: |
           bunx release-please release-pr \
-            --repo-url="${{ github.repository }}" \
+            --repo-url="${REPO_URL}" \
             --config-file=.github/.release-please-config.json \
             --manifest-file=.github/.release-please-manifest.json \
             --token="${GITHUB_TOKEN}"
-        env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -103,12 +103,14 @@ jobs:
       - name: Upload release assets
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release upload "${{ needs.create-draft-release.outputs.tag_name }}" lib/git-harvest
+          TAG_NAME: ${{ needs.create-draft-release.outputs.tag_name }}
+        run: gh release upload "${TAG_NAME}" lib/git-harvest
 
       - name: Publish Release
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release edit "${{ needs.create-draft-release.outputs.tag_name }}" --draft=false
+          TAG_NAME: ${{ needs.create-draft-release.outputs.tag_name }}
+        run: gh release edit "${TAG_NAME}" --draft=false
 
   npm-publish:
     needs: create-draft-release

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,6 +15,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# デフォルト権限を無効化し、各ジョブで必要最小限の権限のみ付与する
+permissions: {}
+
 defaults:
   run:
     shell: bash
@@ -23,10 +26,14 @@ jobs:
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read  # required by actions/checkout to fetch repository code and dorny/paths-filter to diff against the base ref
 
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Check for changes
         uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1


### PR DESCRIPTION
## Summary

Migration PR (#106) に stacked。zizmor auditor persona の finding を全部解消する。

## Fixes
- `_github-actions.yaml` / `_pull-request.yaml`: permissions justification コメント
- `test.yaml`: top-level `permissions: {}` + job 最小 permissions + `persist-credentials: false`
- `release.yaml`:
  - `persist-credentials: false`
  - `release-please github-release` / `release-please release-pr` の `${{ github.repository }}` を `REPO_URL` env 経由に refactor
  - `upload-assets` ジョブの `gh release upload` / `gh release edit` の `${{ needs.create-draft-release.outputs.tag_name }}` を `TAG_NAME` env 経由に refactor
  - permissions justification コメント

## Test plan
- [x] `github-actions / required` 緑
- [x] `github-actions / zizmor` 緑
- [x] `secret-scan / secretlint` 緑
- [x] `pull-request / validate` 緑
