### PR TITLE
fix: forbid BREAKING CHANGE footer for ops-only changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,7 @@ bun install
 - PR タイトルは英語 semantic 形式で記述する。
 - ブランチ保護は **GitHub Rulesets のみ**で管理する。従来の Branch Protection Rules は使用しない。
 - Rulesets の bypass_actors は空（誰も bypass 不可）を維持する。
+- `BREAKING CHANGE:` フッターは **`git-harvest` の公開 API（CLI のコマンド・オプション・出力フォーマット）の互換性を破る変更にのみ**使用する。CI / workflows / branch protection / リポジトリ運用上の変更には使わない（release-please が `bump-minor-pre-major: true` の設定下で minor bump を実行し、CHANGELOG に Breaking Changes として表示してしまうため。実例: PR #106 で workflow 移行を BREAKING CHANGE と書いたことで 0.1.x → 0.2.0 と誤判定された）。これらの注意事項は PR 本文に記述する。
 
 ## テストスタイル
 


### PR DESCRIPTION
## 概要

PR #106 で commit message に書いた `BREAKING CHANGE:` フッターが原因で、release-please が 0.1.20 → **0.2.0** の minor bump を実行し、CHANGELOG にも `⚠ BREAKING CHANGES` セクションを生成してしまった事故の再発防止。

実際の変更は CI / branch protection の運用上の調整であり、`git-harvest` npm パッケージの公開 API（CLI のコマンド・オプション・出力フォーマット）には影響しない。にもかかわらず Conventional Commits 規約上の「破壊的変更」シグナルを使ってしまったのが原因。

## 変更内容

- `CLAUDE.md` の「Git・GitHub 運用ルール」に、`BREAKING CHANGE:` フッターは公開 API の互換性を破る変更にのみ使用するというルールを追記。
- 同等の指示はグローバル設定 (`~/.claude/CLAUDE.md`) にもローカルで反映済み（このリポジトリ外）。

## 関連

- PR #106（事故が起きた PR）
- PR #88（誤って 0.2.0 として生成された release PR — close 済み）
- a85c139 → main の history rewrite で `BREAKING CHANGE:` フッターを除去し、release-please が 0.1.21 として PR を再生成する想定。
