### PR TITLE
fix(ci): skip prepare script on npm publish

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -134,8 +134,10 @@ jobs:
           node-version: lts/*
           registry-url: https://registry.npmjs.org
 
+      # publish 時に prepare（lefthook install）が走ると devDependencies 未インストールで落ちる。
+      # git-harvest は shell スクリプト配布で publish 時のビルド工程は無いため、scripts は無効化する。
       - name: Publish to npm
-        run: npm publish
+        run: npm publish --ignore-scripts
 
   # publish 後に次の release PR を作成/更新
   release-pr:


### PR DESCRIPTION
## 概要

[Release ワークフロー実行 #25597918560](https://github.com/nozomiishii/git-harvest/actions/runs/25597918560) で `npm-publish` ジョブが exit 127 で失敗した問題を修正します。`npm publish` に `--ignore-scripts` を付与し、`prepare` スクリプトの実行をスキップします。

## 原因

[#124](https://github.com/nozomiishii/git-harvest/pull/124) で lefthook を導入した際、`package.json` に `"prepare": "lefthook install --force"` が追加されました。`npm publish` は実行時に自動で `prepare` を走らせますが、`npm-publish` ジョブは `actions/setup-node` で Node をセットアップしたあと **依存をインストールせず直接 `npm publish` を呼ぶ** パスのため、devDependencies の `lefthook` バイナリが存在せず以下のエラーで落ちていました。

```
> git-harvest@0.1.24 prepare
> lefthook install --force
sh: 1: lefthook: not found
npm error code 127
```

`create-draft-release` / `release-pr` ジョブは `bun install --frozen-lockfile` をしているため影響なし。`npm-publish` ジョブのみ regression の対象でした。

## 対応

`npm-publish` ジョブの `npm publish` に `--ignore-scripts` を付与しました。git-harvest は shell スクリプトをそのまま配布する構成で、publish 時に走らせる必要のあるビルド・生成系のスクリプトは存在しないため、scripts 全体を無効化しても問題ありません。意図が伝わるよう YAML にコメントも添えています。

## 注意

- 0.1.24 は draft release / GitHub Release publish までは進んでいますが、**npm レジストリには publish されていない** 状態です。
- このマージ後の対応は別途相談したい:
  - 案 1: マージ後にローカルから `npm publish` を手動実行して 0.1.24 を埋める
  - 案 2: 0.1.24 はスキップして、次のリリース（0.1.25）で巻き直す

## テスト計画

- [ ] このブランチに対しては GitHub Actions の `release.yaml` は走らないため、変更は次のリリース時に検証される
- [ ] マージ後の最初のリリースで `npm-publish` ジョブが成功することを確認する
