### PR TITLE
feat: tighten output spacing and left-align sections

### DIFF
--- a/lib/git-harvest
+++ b/lib/git-harvest
@@ -111,19 +111,19 @@ print_logo() {
 
 # ブランド wordmark を表示
 wordmark() {
-  printf '\n  %s\n\n' "$(brand 'git harvest')"
+  printf '\n%s\n' "$(brand 'git harvest')"
 }
 
 # ✓ で removed 表示
 print_removed() {
   local item="$1"
-  printf '    %s  %s\n' "$(hi ✓)" "$item"
+  printf '  %s  %s\n' "$(hi ✓)" "$item"
 }
 
 # → で would-remove 表示
 print_will_remove() {
   local item="$1"
-  printf '    %s  %s\n' "$(hi →)" "$item"
+  printf '  %s  %s\n' "$(hi →)" "$item"
 }
 
 # · で growing 表示（保護理由付き、path と reason の間に最低 2 spaces 確保）
@@ -132,9 +132,9 @@ print_growing() {
   local pad=$((38 - ${#item}))
   [ $pad -lt 2 ] && pad=2
   if [ "$USE_COLOR" = true ]; then
-    printf '    \033[2m·  %s%*s%s\033[0m\n' "$item" "$pad" '' "$reason"
+    printf '  \033[2m·  %s%*s%s\033[0m\n' "$item" "$pad" '' "$reason"
   else
-    printf '    ·  %s%*s%s\n' "$item" "$pad" '' "$reason"
+    printf '  ·  %s%*s%s\n' "$item" "$pad" '' "$reason"
   fi
 }
 
@@ -460,7 +460,7 @@ cleanup_worktrees() {
     [ "$branch" = "$base" ] && continue
 
     if [ "$found" = false ]; then
-      printf '\n  %s\n' "$(bold Worktrees)"
+      printf '\n%s\n' "$(bold Worktrees)"
       found=true
     fi
 
@@ -536,7 +536,7 @@ cleanup_branches() {
     [ "$branch" = "$base" ] && continue
 
     if [ "$found" = false ]; then
-      printf '\n  %s\n' "$(bold Branches)"
+      printf '\n%s\n' "$(bold Branches)"
       found=true
     fi
 
@@ -599,7 +599,7 @@ main() {
   wordmark
 
   if [ "$DRY_RUN" = true ]; then
-    printf '  %s\n' "$(dim 'Dry run mode - nothing will be deleted')"
+    printf '\n%s\n' "$(dim 'Dry run mode - nothing will be deleted')"
   fi
 
   local all_branches
@@ -671,7 +671,7 @@ main() {
   done <<<"$all_branches"
 
   if [ "$other_branch_count" -eq 0 ] && [ "$linked_wt_count" -eq 0 ]; then
-    printf '\n  %s\n\n' "$(dim '· Nothing to harvest. All clean.')"
+    printf '\n%s\n\n' "$(dim '· Nothing to harvest. All clean.')"
   else
     # worktree が参照中のブランチは削除できないため、worktree を先に削除する
     DELETED_COUNT=0
@@ -685,18 +685,18 @@ main() {
       if [ "$DELETED_COUNT" -eq 1 ]; then item_word="item"; else item_word="items"; fi
       elapsed=$(elapsed_str "$start_ms")
       if [ "$DRY_RUN" = true ]; then
-        printf '  %s %s  %s\n\n' \
+        printf '%s %s  %s\n\n' \
           "$(hi →)" \
           "$(bold "Would harvest $DELETED_COUNT $item_word")" \
           "$(dim "in $elapsed")"
       else
-        printf '  %s %s  %s\n\n' \
+        printf '%s %s  %s\n\n' \
           "$(hi ✓)" \
           "$(bold "Harvested $DELETED_COUNT $item_word")" \
           "$(dim "in $elapsed")"
       fi
     else
-      printf '  %s\n\n' "$(dim '· Nothing to harvest. All growing.')"
+      printf '%s\n\n' "$(dim '· Nothing to harvest. All growing.')"
     fi
   fi
 


### PR DESCRIPTION
## Summary

- `git harvest` ヘッダーと `Worktrees` セクションの間の余白を 2 行から 1 行に詰めた
- セクション見出し (`Worktrees` / `Branches` / summary 行 / dry-run 通知 / nothing-to-harvest メッセージ) を 2-space インデントから左端揃えに変更
- アイテム行 (`✓` / `→` / `·`) のインデントを 4-space から 2-space に揃え、全体を左に寄せた

## 動機

出力が右にずれて視線が散るので、左端基準の minimal レイアウトに揃えた。階層は見出し (col 0) → アイテム (col 2) のみで判別できるため、wrapper 余白は不要と判断。

## 確認

- `bun test lib/git-harvest.test.ts` → 58 pass / 0 fail
- 仮リポジトリで `--dry-run` を実行し、`git harvest` ↔ `Worktrees` が 1 blank、全行が左寄せになっていることを目視確認
