### PR TITLE
chore: drop "(recommended)" from Shell install heading

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -42,7 +42,7 @@ echo "alias 'ghv!'='npx -y git-harvest@latest --all'" >> ~/.zshrc
 
 ## インストール
 
-### Shell (macOS/Linux) (recommended)
+### Shell (macOS/Linux)
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/nozomiishii/git-harvest/main/install.sh | bash

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ echo "alias 'ghv!'='npx -y git-harvest@latest --all'" >> ~/.zshrc
 
 ## Install
 
-### Shell (macOS/Linux) (recommended)
+### Shell (macOS/Linux)
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/nozomiishii/git-harvest/main/install.sh | bash


### PR DESCRIPTION
## 概要

README の Install セクションにある `### Shell (macOS/Linux) (recommended)` 見出しから `(recommended)` を削除しました。

## 背景

git-harvest は変更ペースが早く、`install.sh` 経由でローカルに固定したバージョンを使い続けるより、`npx -y git-harvest@latest` のように都度最新を直接実行してもらう方が望ましい運用になっています。`(recommended)` の表記が残っていると Shell インストールを最優先で勧めているように読めてしまうため、推奨表現を外してフラットに並べる形にしました。

## 変更内容

- `README.md`: `### Shell (macOS/Linux) (recommended)` → `### Shell (macOS/Linux)`
- `README.ja.md`: 同上

インストール手段の節構成自体は据え置きです。
