### PR TITLE
chore: restructure README to recommend direct execution

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -11,7 +11,9 @@
 branch と worktree を自動で整理するツール
 
 
-## インストールせずに直接実行
+## インストールせずに直接実行 (推奨)
+
+常に最新版が走るので、アップデート作業は不要です。
 
 ```sh
 # bun
@@ -40,7 +42,29 @@ echo "alias ghv='npx -y git-harvest@latest'" >> ~/.zshrc
 echo "alias 'ghv!'='npx -y git-harvest@latest --all'" >> ~/.zshrc
 ```
 
-## インストール
+## おすすめの運用法
+
+Git hooksのpost-mergeコマンドと合わせることで、Mergeやpullした際に自動で収穫もできます。
+
+### [lefthook](https://github.com/evilmartians/lefthook)との連携
+
+Git Hooks にはhusky、pre-commit、simple-git-hooks など様々なツールがありますが、Lefthook が言語に依存せず monorepo にも組み込みやすいのでおすすめです。さらに lefthook-local.yaml を使えば、チーム開発で他のメンバーに影響を与えず自分だけ実行する運用も可能です。
+
+
+```yaml
+# lefthook-local.yaml
+post-merge:
+  commands:
+    git-harvest:
+      run: npx -y git-harvest@latest
+      # or: bunx git-harvest@latest
+      # or: pnpx git-harvest@latest
+```
+
+<details>
+<summary><b>その他のインストール方法</b></summary>
+
+<br>
 
 ### Shell (macOS/Linux)
 
@@ -73,12 +97,13 @@ echo "alias 'ghv!'='git-harvest --all'" >> ~/.zshrc
 git config --global alias.harvest '!git-harvest'
 ```
 
-
-## アンインストール
+### アンインストール
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/nozomiishii/git-harvest/main/uninstall.sh | bash
 ```
+
+</details>
 
 
 ## 使い方
@@ -95,25 +120,6 @@ git-harvest --version  # バージョンを表示
 git-harvest --dry-run  # 実際には削除せず、削除対象を表示
 git-harvest --all      # デフォルトブランチ以外の全ブランチ・worktree を削除
 git-harvest logo       # git-harvest のロゴを表示
-```
-
-## おすすめの運用法
-
-Git hooksのpost-mergeコマンドと合わせることで、Mergeやpullした際に自動で収穫もできます。
-
-### [lefthook](https://github.com/evilmartians/lefthook)との連携
-
-Git Hooks にはhusky、pre-commit、simple-git-hooks など様々なツールがありますが、Lefthook が言語に依存せず monorepo にも組み込みやすいのでおすすめです。さらに lefthook-local.yaml を使えば、チーム開発で他のメンバーに影響を与えず自分だけ実行する運用も可能です。
-
-
-```yaml
-# lefthook-local.yaml
-post-merge:
-  commands:
-    git-harvest:
-      run: npx -y git-harvest@latest
-      # or: bunx git-harvest@latest
-      # or: pnpx git-harvest@latest
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ English | [日本語](./README.ja.md)
 Clean up branches and worktrees.
 
 
-## Run directly without installing
+## Run directly without installing (Recommended)
+
+Always runs the latest version — no separate update step needed.
 
 ```sh
 # bun
@@ -40,7 +42,29 @@ echo "alias ghv='npx -y git-harvest@latest'" >> ~/.zshrc
 echo "alias 'ghv!'='npx -y git-harvest@latest --all'" >> ~/.zshrc
 ```
 
-## Install
+## Recommended workflow
+
+By combining with Git hooks' post-merge command, you can automatically harvest after every merge or pull.
+
+### With [lefthook](https://github.com/evilmartians/lefthook)
+
+There are many Git hook tools such as husky, pre-commit, and simple-git-hooks, but Lefthook is recommended because it is language-agnostic and easy to integrate into monorepos. Additionally, by using lefthook-local.yaml, you can run hooks only for yourself without affecting other team members.
+
+
+```yaml
+# lefthook-local.yaml
+post-merge:
+  commands:
+    git-harvest:
+      run: npx -y git-harvest@latest
+      # or: bunx git-harvest@latest
+      # or: pnpx git-harvest@latest
+```
+
+<details>
+<summary><b>Other install methods</b></summary>
+
+<br>
 
 ### Shell (macOS/Linux)
 
@@ -73,12 +97,13 @@ echo "alias 'ghv!'='git-harvest --all'" >> ~/.zshrc
 git config --global alias.harvest '!git-harvest'
 ```
 
-
-## Uninstall
+### Uninstall
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/nozomiishii/git-harvest/main/uninstall.sh | bash
 ```
+
+</details>
 
 ## Usage
 
@@ -94,25 +119,6 @@ git-harvest --version  # Show version
 git-harvest --dry-run  # Show what would be deleted without actually deleting
 git-harvest --all      # Delete all branches and worktrees except the default branch
 git-harvest logo       # Show the git-harvest logo
-```
-
-## Recommended workflow
-
-By combining with Git hooks' post-merge command, you can automatically harvest after every merge or pull.
-
-### With [lefthook](https://github.com/evilmartians/lefthook)
-
-There are many Git hook tools such as husky, pre-commit, and simple-git-hooks, but Lefthook is recommended because it is language-agnostic and easy to integrate into monorepos. Additionally, by using lefthook-local.yaml, you can run hooks only for yourself without affecting other team members.
-
-
-```yaml
-# lefthook-local.yaml
-post-merge:
-  commands:
-    git-harvest:
-      run: npx -y git-harvest@latest
-      # or: bunx git-harvest@latest
-      # or: pnpx git-harvest@latest
 ```
 
 


### PR DESCRIPTION
## Summary

- `Run directly without installing` を推奨に格上げ（`(Recommended)` / `(推奨)` を見出しに追加）し、「常に最新版が走るのでアップデート作業は不要」という一言を直下に追加
- `Recommended workflow` / `おすすめの運用法` セクションを直接実行セクションの直後に移動し、推奨フロー（bunx/pnpx/npx）が連続して読める構成に変更
- `Install` (Shell / Homebrew) と `Uninstall` を `<details><summary>Other install methods</summary>` で折りたたみ、最新版から外れる install 系を視覚的に de-emphasize

## Motivation

curl install と Homebrew 経由のインストールはまだ安定とは言えず、できるだけ最新版を使ってもらいたいので、bunx/npx 推奨を README の主動線にした。既存ユーザーの動線（curl install スクリプトの URL や brew tap）は折りたたみで残しているので破壊変更はなし。

## Test plan

- [ ] GitHub 上で README.md / README.ja.md のレンダリングを確認（`<details>` が正しく折りたたまれる）
- [ ] 日本語版・英語版で構成が同じになっていることを確認
