### PR TITLE
feat!: remove --update self-update command

### DIFF
--- a/lib/git-harvest
+++ b/lib/git-harvest
@@ -2,10 +2,6 @@
 set -euo pipefail
 
 VERSION="0.1.28" # x-release-please-version
-REPO="nozomiishii/git-harvest"
-CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/git-harvest"
-CACHE_FILE="$CACHE_DIR/latest-version"
-CHECK_INTERVAL=86400 # 24時間（秒）
 
 # git-harvest のブランドカラー #C0FF39 rgb(192, 255, 57)
 BRAND_COLOR='192;255;57'
@@ -139,117 +135,6 @@ print_growing() {
 }
 
 # ---------------------------------------------------------------------------
-# バージョン更新チェック
-# ---------------------------------------------------------------------------
-
-# インストール経路を判定し、自動更新チェックの対象かどうかを返す
-# Homebrew / npm 経由のインストールはパッケージマネージャーに任せる
-should_check_update() {
-  local resolved
-  resolved=$(realpath "$0" 2>/dev/null || echo "$0")
-  case "$resolved" in
-    */Cellar/*|*/homebrew/*) return 1 ;;
-    */node_modules/*)        return 1 ;;
-  esac
-  return 0
-}
-
-# バックグラウンドで GitHub API から最新バージョンを取得しキャッシュに保存
-check_update_async() {
-  should_check_update || return 0
-
-  # TTL チェック: キャッシュが新しければスキップ
-  if [ -f "$CACHE_FILE" ]; then
-    local last_check now
-    last_check=$(stat -c %Y "$CACHE_FILE" 2>/dev/null \
-              || stat -f %m "$CACHE_FILE" 2>/dev/null || echo 0)
-    now=$(date +%s)
-    if (( now - last_check < CHECK_INTERVAL )); then
-      return 0
-    fi
-  fi
-
-  mkdir -p "$CACHE_DIR"
-  # バックグラウンドで取得（メイン処理をブロックしない）
-  (
-    local tag
-    tag=$(curl -fsSL --max-time 5 \
-      "https://api.github.com/repos/${REPO}/releases/latest" 2>/dev/null \
-      | grep -o '"tag_name":"[^"]*"' | head -1 \
-      | sed 's/"tag_name":"v\{0,1\}\([^"]*\)"/\1/')
-    if [ -n "$tag" ]; then
-      echo "$tag" > "$CACHE_FILE"
-    fi
-  ) &
-  UPDATE_CHECK_PID=$!
-}
-
-# メイン処理完了後に呼び出し、新しいバージョンがあれば stderr に通知
-show_update_notification() {
-  should_check_update || return 0
-  [ -f "$CACHE_FILE" ] || return 0
-
-  local latest
-  latest=$(cat "$CACHE_FILE" 2>/dev/null)
-  [ -z "$latest" ] && return 0
-  [ "$latest" = "$VERSION" ] && return 0
-
-  cat >&2 <<EOF
-
-Update available: v${VERSION} -> v${latest}
-Run: git-harvest --update
-
-EOF
-}
-
-# 自分自身を最新版に置き換える
-self_update() {
-  local install_path
-  install_path=$(realpath "$0" 2>/dev/null || echo "$0")
-
-  # Homebrew / npm 経由の場合はパッケージマネージャーを案内
-  case "$install_path" in
-    */Cellar/*|*/homebrew/*)
-      echo "Installed via Homebrew. Please update with:" >&2
-      echo "  brew upgrade git-harvest" >&2
-      exit 1
-      ;;
-    */node_modules/*)
-      echo "Installed via npm. Please update with:" >&2
-      echo "  npm update -g git-harvest" >&2
-      exit 1
-      ;;
-  esac
-
-  # 書き込み権限チェック
-  if ! [ -w "$install_path" ]; then
-    echo "Error: No write permission for $install_path" >&2
-    echo "  Retry with: sudo git-harvest --update" >&2
-    exit 1
-  fi
-
-  echo "Updating git-harvest..."
-  local tmp
-  tmp=$(mktemp)
-  # 最新リリースをダウンロードして置き換え
-  if curl -fsSL --max-time 30 \
-    "https://github.com/${REPO}/releases/latest/download/git-harvest" \
-    -o "$tmp" 2>/dev/null; then
-    chmod +x "$tmp"
-    mv "$tmp" "$install_path"
-    rm -f "$CACHE_FILE"
-    local new_version
-    new_version=$("$install_path" --version)
-    echo "Updated to ${new_version}"
-  else
-    rm -f "$tmp"
-    echo "Error: Download failed" >&2
-    exit 1
-  fi
-  exit 0
-}
-
-# ---------------------------------------------------------------------------
 # 引数パース
 # ---------------------------------------------------------------------------
 
@@ -265,9 +150,6 @@ while [ $# -gt 0 ]; do
   logo)
     print_logo
     exit 0
-    ;;
-  --update)
-    self_update
     ;;
   -n | --dry-run)
     DRY_RUN=true
@@ -286,7 +168,6 @@ Options:
   -v, --version  Show version
   -n, --dry-run  Show what would be deleted without actually deleting
   --all          Delete all branches and worktrees except the default branch
-  --update       Update to the latest version
 
 Subcommands:
   logo           Show the git-harvest logo
@@ -558,10 +439,6 @@ cleanup_branches() {
 # ---------------------------------------------------------------------------
 
 main() {
-  # バックグラウンドでバージョンチェックを開始
-  UPDATE_CHECK_PID=""
-  check_update_async
-
   local start_ms
   start_ms=$(now_ms)
 
@@ -682,12 +559,6 @@ main() {
       printf '%s\n\n' "$(dim '· Nothing to harvest. All growing.')"
     fi
   fi
-
-  # バックグラウンドのバージョンチェックを待機して通知表示
-  if [ -n "$UPDATE_CHECK_PID" ]; then
-    wait "$UPDATE_CHECK_PID" 2>/dev/null || true
-  fi
-  show_update_notification
 }
 
 main

--- a/lib/git-harvest.test.ts
+++ b/lib/git-harvest.test.ts
@@ -1,19 +1,16 @@
 import { execSync, spawn } from 'child_process';
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 
 const SCRIPT = join(import.meta.dir, 'git-harvest');
 
-// テスト用キャッシュディレクトリ（~/.cache への書き込みを避ける）
-const TEST_CACHE_DIR = mkdtempSync(join(tmpdir(), 'git-harvest-test-cache-'));
 // Claude 関連パスを空ディレクトリに向けて、ユーザーの実 ~/.claude を見ないように隔離する
 const TEST_CLAUDE_SESSIONS_DIR = mkdtempSync(join(tmpdir(), 'git-harvest-claude-sessions-'));
 const TEST_ENV = {
   ...process.env,
   NO_COLOR: '1',
-  XDG_CACHE_HOME: TEST_CACHE_DIR,
   GIT_HARVEST_CLAUDE_SESSIONS_DIR: TEST_CLAUDE_SESSIONS_DIR,
 };
 
@@ -101,14 +98,13 @@ afterEach(() => {
   rmSync(repo, { recursive: true, force: true });
 });
 
-describe('--help / --version / --update', () => {
+describe('--help / --version', () => {
   // ヘルプ表示（--all を含む）
   test('prints help and exits with 0', () => {
     const output = run(repo, '--help');
     expect(output).toContain('Usage: git-harvest');
     expect(output).toContain('--help');
     expect(output).toContain('--version');
-    expect(output).toContain('--update');
     expect(output).toContain('--all');
   });
 
@@ -664,118 +660,6 @@ describe('combined scenarios', () => {
     // run() は execSync なので失敗したら throw される
     // 正常に返ることが exit 0 の証明
     run(repo);
-  });
-});
-
-describe('update check', () => {
-  // should_check_update: Homebrew パスではチェックしない
-  test('should_check_update returns false for homebrew paths', () => {
-    const homebrewDir = mkdtempSync(join(tmpdir(), 'git-harvest-homebrew-'));
-    const fakeBrewPath = join(homebrewDir, 'homebrew', 'bin');
-    mkdirSync(fakeBrewPath, { recursive: true });
-    const fakeBin = join(fakeBrewPath, 'git-harvest');
-    execSync(`cp ${SCRIPT} ${fakeBin}`);
-    execSync(`chmod +x ${fakeBin}`);
-
-    try {
-      // Homebrew パスからの実行ではバージョンチェックのキャッシュファイルが作られない
-      const cacheDir = mkdtempSync(join(tmpdir(), 'git-harvest-cache-'));
-      execSync(`bash ${fakeBin} --version`, {
-        encoding: 'utf-8',
-        env: { ...process.env, XDG_CACHE_HOME: cacheDir },
-      });
-      // --version は即終了するのでチェックは走らないが、should_check_update が
-      // homebrew パスを正しく判定することを間接的に確認
-      expect(fakeBin).toContain('homebrew');
-      rmSync(cacheDir, { recursive: true, force: true });
-    } finally {
-      rmSync(homebrewDir, { recursive: true, force: true });
-    }
-  });
-
-  // should_check_update: node_modules パスではチェックしない
-  test('should_check_update returns false for node_modules paths', () => {
-    const nmDir = mkdtempSync(join(tmpdir(), 'git-harvest-nm-'));
-    const fakeNmPath = join(nmDir, 'node_modules', '.bin');
-    mkdirSync(fakeNmPath, { recursive: true });
-    const fakeBin = join(fakeNmPath, 'git-harvest');
-    execSync(`cp ${SCRIPT} ${fakeBin}`);
-    execSync(`chmod +x ${fakeBin}`);
-
-    try {
-      expect(fakeBin).toContain('node_modules');
-    } finally {
-      rmSync(nmDir, { recursive: true, force: true });
-    }
-  });
-
-  // キャッシュに新しいバージョンがある場合、通知が stderr に表示される
-  test('shows update notification when cache has newer version', () => {
-    const cacheDir = mkdtempSync(join(tmpdir(), 'git-harvest-cache-'));
-    const ghCacheDir = join(cacheDir, 'git-harvest');
-    mkdirSync(ghCacheDir, { recursive: true });
-    writeFileSync(join(ghCacheDir, 'latest-version'), '99.99.99');
-
-    try {
-      const result = execSync(`bash ${SCRIPT} --version 2>&1 || true`, {
-        cwd: repo,
-        encoding: 'utf-8',
-        env: { ...process.env, XDG_CACHE_HOME: cacheDir },
-      });
-      // --version は即 exit するのでメイン処理の通知は出ないが、
-      // main 経由での通知テストは以下で行う
-    } finally {
-      rmSync(cacheDir, { recursive: true, force: true });
-    }
-  });
-
-  // メイン実行で通知が stderr に出る（キャッシュに新バージョンがある場合）
-  test('displays update notification on stderr after main execution', () => {
-    const cacheDir = mkdtempSync(join(tmpdir(), 'git-harvest-cache-'));
-    const ghCacheDir = join(cacheDir, 'git-harvest');
-    mkdirSync(ghCacheDir, { recursive: true });
-    // キャッシュに新しいバージョンを書き込み（TTL 内なのでネットワークアクセスなし）
-    writeFileSync(join(ghCacheDir, 'latest-version'), '99.99.99');
-
-    try {
-      // stderr を含めて出力をキャプチャ
-      const result = execSync(`bash ${SCRIPT} 2>&1`, {
-        cwd: repo,
-        encoding: 'utf-8',
-        env: { ...process.env, NO_COLOR: '1', XDG_CACHE_HOME: cacheDir },
-      });
-      expect(result).toContain('Update available');
-      expect(result).toContain('99.99.99');
-      expect(result).toContain('git-harvest --update');
-    } finally {
-      rmSync(cacheDir, { recursive: true, force: true });
-    }
-  });
-
-  // キャッシュのバージョンが現在と同じなら通知しない
-  test('does not show notification when cache version matches current', () => {
-    const cacheDir = mkdtempSync(join(tmpdir(), 'git-harvest-cache-'));
-    const ghCacheDir = join(cacheDir, 'git-harvest');
-    mkdirSync(ghCacheDir, { recursive: true });
-    // 現在のバージョンを取得してキャッシュに書き込む
-    const currentVersion = execSync(`bash ${SCRIPT} --version`, {
-      encoding: 'utf-8',
-      env: TEST_ENV,
-    })
-      .trim()
-      .replace('git-harvest v', '');
-    writeFileSync(join(ghCacheDir, 'latest-version'), currentVersion);
-
-    try {
-      const result = execSync(`bash ${SCRIPT} 2>&1`, {
-        cwd: repo,
-        encoding: 'utf-8',
-        env: { ...process.env, NO_COLOR: '1', XDG_CACHE_HOME: cacheDir },
-      });
-      expect(result).not.toContain('Update available');
-    } finally {
-      rmSync(cacheDir, { recursive: true, force: true });
-    }
   });
 });
 


### PR DESCRIPTION
## Summary

brew / curl 経由のインストール方法を非推奨にした（[#148](https://github.com/nozomiishii/git-harvest/pull/148)）ことに合わせて、自前で更新する用途が失われた `--update` コマンドと付随する update check 機構を全削除する。

- `--update` フラグと `self_update()` を削除
- バックグラウンドの update check (`check_update_async` / `show_update_notification` / `should_check_update`) を削除
- 関連定数 `REPO` / `CACHE_DIR` / `CACHE_FILE` / `CHECK_INTERVAL` と `main()` の wiring を削除
- `--help` 出力から `--update` の行を削除
- テストの `describe('update check', ...)` ブロックと `--update` 検証を削除

## Why

推奨経路となった `bunx / npx / pnpx git-harvest@latest` は常に最新版が走る。brew / npm 経由のユーザーは元々パッケージマネージャー任せ。残った curl install のユーザーも非推奨化により今後は再 install で更新できる前提なので、CLI 側の self-update を維持するメリットがなくなった。

## Breaking change

CLI から `--update` オプションを削除する。`git-harvest --update` の呼び出しは `Unknown option: --update` でエラー終了するようになる。バックグラウンドで `~/.cache/git-harvest/latest-version` を書き出していたキャッシュも書かれなくなる（既存のキャッシュは害がないため自動削除はしない）。

## Test plan

- [x] `bash -n lib/git-harvest` — syntax OK
- [x] `bun test lib/git-harvest.test.ts` — 54 pass / 0 fail
- [x] `bash lib/git-harvest --help` で `--update` が出ないことを目視確認
