### PR TITLE
fix: scope release app token permissions and pin op cli version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,6 +35,9 @@ jobs:
       - name: Load secrets from 1Password
         id: secrets
         uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4
+        with:
+          # renovate: datasource=docker depName=1password/op versioning=semver
+          version: "2.34.0"
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           APP_ID: op://github-app/nozomiishii-release/username
@@ -46,6 +49,8 @@ jobs:
         with:
           client-id: ${{ steps.secrets.outputs.APP_ID }}
           private-key: ${{ steps.secrets.outputs.APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -153,6 +158,9 @@ jobs:
       - name: Load secrets from 1Password
         id: secrets
         uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4
+        with:
+          # renovate: datasource=docker depName=1password/op versioning=semver
+          version: "2.34.0"
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           APP_ID: op://github-app/nozomiishii-release/username
@@ -164,6 +172,8 @@ jobs:
         with:
           client-id: ${{ steps.secrets.outputs.APP_ID }}
           private-key: ${{ steps.secrets.outputs.APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## 概要

zizmor v1.25 の以下 2 つの audit が release workflow の CI を落とすため、先回りで正攻法に修正する。

- `github-app` (high): `actions/create-github-app-token` が blanket な権限でトークンを発行している
- `unpinned-tools` (medium): `1password/load-secrets-action` の op CLI version が未指定

## 変更内容

- `actions/create-github-app-token`（`create-draft-release` / `release-pr` の 2 箇所）に最小権限を明示
  - `permission-contents: write`
  - `permission-pull-requests: write`
  - どちらも release-please CLI で release/tag 作成 + PR 操作を行うため contents + pull-requests のみ付与
- `1password/load-secrets-action`（同 2 箇所）に op CLI version を pin
  - `version: "2.34.0"`（renovate annotation 付き）

## 補足

`issues` 権限は GitHub App (`nozomiishii-release`) に付与されていないため要求しない（要求すると release が 422 で落ちる）。

## 検証

`uvx zizmor --persona=auditor` で release.yaml を監査し `No findings to report` を確認済み。
