### PR TITLE
chore: unset stale core.hooksPath in worktree startup hook

### DIFF
--- a/.claude/hooks/startup.sh
+++ b/.claude/hooks/startup.sh
@@ -2,6 +2,13 @@
 set -euo pipefail
 # セッション開始時に worktree を整える（可能なら origin/main 取り込み、必要なら deps install）。
 
+# Claude Code の worktree 作成(EnterWorktree)が共有 .git/config に core.hooksPath を書き込む。
+# 値はデフォルト(.git/hooks)と同じで冗長だが、lefthook が「独自パス」とみなし commit ごとの
+# self-sync で "Skipping hook sync" 警告を毎回出す。後段の merge --ff-only が走らせる
+# post-merge hook より前に unset して打ち消す（--unset-all は未設定だと exit 5 なので保険を付ける）。
+# 上流バグ: https://github.com/anthropics/claude-code/issues/27474
+git config --unset-all --local core.hooksPath 2>/dev/null || true
+
 git fetch origin --quiet
 
 # 既存の commit や未保存変更を壊さない範囲で HEAD を origin/main まで進める。


### PR DESCRIPTION
## 概要

Claude Code の worktree で走る SessionStart フック `startup.sh` の冒頭に、共有 `.git/config` の `core.hooksPath` を unset する処理を追加した。

## 背景・原因

- Claude Code の `EnterWorktree`（ネイティブ worktree 作成）は、worktree を作るたびに共有 `.git/config` へ `core.hooksPath = <repo>/.git/hooks`（main repo の絶対パス）を書き込む。
- この値は git のデフォルト（worktree でも `.git/hooks` を参照）と同じで、**機能的には冗長**。
- ところが lefthook はこれを「独自 hooksPath」とみなすガードを持つため、git 操作のたびの self-sync（`--force` なし）が以下を**毎回**出す:

  ```
  Skipping hook sync: core.hooksPath is set locally to '.../.git/hooks'
  ```

- `prepare` の `lefthook install --force` や `lefthook install --reset-hooks-path` は対症療法で、次の worktree 作成で `EnterWorktree` が書き戻すため再発する（いたちごっこ）。

## 対策

`startup.sh` の `git fetch` / `merge --ff-only`（= post-merge hook を走らせる）より**前**で `core.hooksPath` を unset し、session 開始時に打ち消す。`--unset-all` は未設定時に exit 5 を返すので `set -e` 対策の保険を付けている。

## 関連 Claude Code issue（上流バグ）

- [anthropics/claude-code#27474](https://github.com/anthropics/claude-code/issues/27474) — **canonical**（OPEN, 最終更新 2026-05-18）: `claude --worktree` が `$GIT_COMMON_DIR/config` の `core.hooksPath` を上書きする。今回の症状と一致。[#30251](https://github.com/anthropics/claude-code/issues/30251) はこの duplicate として close 済み。
- [anthropics/claude-code#60620](https://github.com/anthropics/claude-code/issues/60620) — 関連（OPEN, 2026-05-19, `area:hooks`）: per-worktree `config.worktree` に絶対パスが書かれる変種。
- [anthropics/claude-code#58345](https://github.com/anthropics/claude-code/issues/58345) — 関連（OPEN, 2026-05-18）: EnterWorktree/ExitWorktree が git config（`core.bare` / `core.hooksPath`）を壊すファミリー。
- [anthropics/claude-code#57716](https://github.com/anthropics/claude-code/issues/57716) — 関連（OPEN, 2026-05-10）: worktree 作成時に `post-checkout` hook が発火しない。

## メモ

- これは上流バグの **local mitigation**。`type: chore` にして release-please の version bump を避けている（git-harvest の公開 CLI API には無関係なため）。
- `extensions.worktreeConfig` が ON の repo では値が `config.worktree` 行きになり `--local` では消えない。git-harvest は OFF のため `--local` で消える。
