### PR TITLE
chore: add npm version badge to README

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -6,6 +6,10 @@
 <div align="center">
   <img src="demo/logo.gif" alt="logo" width="480" />
 </div>
+
+<p align="center">
+  <a href="https://www.npmjs.com/package/git-harvest"><img src="https://img.shields.io/npm/v/git-harvest.svg" alt="npm version" /></a>
+</p>
 <br>
 
 branch と worktree を自動で整理するツール

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ English | [日本語](./README.ja.md)
 <div align="center">
   <img src="demo/logo.gif" alt="logo" width="480" />
 </div>
+
+<p align="center">
+  <a href="https://www.npmjs.com/package/git-harvest"><img src="https://img.shields.io/npm/v/git-harvest.svg" alt="npm version" /></a>
+</p>
 <br>
 
 Clean up branches and worktrees.


### PR DESCRIPTION
## Summary

- `README.md` / `README.ja.md` のロゴ直下に npm version バッジ (shields.io) を追加
- クリックで [npm パッケージページ](https://www.npmjs.com/package/git-harvest) へ遷移

## Test plan

- [ ] GitHub 上で README プレビューを開き、バッジが表示されること
- [ ] バッジリンクが npm パッケージページへ遷移すること
- [ ] 英語版・日本語版どちらも同じ位置に表示されていること