### PR TITLE
chore: minimal standalone shell samples for default / --yolo (reference, not for merge)

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -1,0 +1,40 @@
+# Minimal standalone shell samples
+
+git-harvest の `default` と `--yolo` の「削除挙動だけ」を切り出した、単体で動く shell スクリプトです。
+
+## 目的
+
+個人ライブラリ（git-harvest）に依存しづらい環境（会社など）でも、同じ掃除をしたいときに 1 ファイルをコピペして使えるリファレンス。本リポジトリにマージはせず、参照用の記録として残しています（この PR は close 済み）。
+
+## 中身
+
+| file | 役割 | 行数（実測） |
+|---|---|---|
+| `git-harvest-default.sh` | merge済 worktree（clean）と base にある branch だけ削除 | 115 行（実質 79 行） |
+| `git-harvest-yolo.sh` | invariant 以外を全削除（未コミット込み、force） | 76 行（実質 55 行） |
+
+どちらも throwaway repo で動作確認済み。
+
+## 挙動
+
+`git-harvest-default.sh`（保守的）:
+
+- worktree: merge済 かつ clean なものだけ削除
+- branch: 独自コミットが base にある（merge済 / 独自コミットなし）ものを削除
+- 保護: main/default worktree・カレント worktree(cwd)・locked・走行中 Claude session・base branch・現在 HEAD・生存 worktree が checkout 中の branch・untouched worktree（未着手の checkout は残す）
+
+`git-harvest-yolo.sh`（危険）:
+
+- worktree: invariant（main/default・カレント cwd・locked・session）以外を未コミット込みで force 削除
+- branch: base・現在 HEAD・生存 worktree が参照中 以外を `-D` 削除
+- 未コミット変更も未マージ commit も確認なしで消える。実行前に対象をよく確認すること
+
+base（default branch）は `origin/HEAD` から fail-closed で解決（取れなければ何もせず exit）。`GIT_HARVEST_CLAUDE_SESSIONS_DIR` で session ディレクトリを上書き可能。
+
+## 含まないもの
+
+削除コアのみ。本家 git-harvest にある dry-run / 色・bold / `--help` / `logo` / 個別 flag 体系（`--worktree-detached` 等）/ 1件ずつ隔離した fail-safe 削除 / サマリー表示 / `fetch --prune` 後処理 は載せていません。これらを足すと容易に倍以上の規模になります。
+
+## アイデア（未実装）
+
+`git harvest eject --yolo` のように、本体から「その preset 相当の単体スクリプト」を吐き出せると、こういうコピペ用ファイルを手で保守せずに済むかもしれません。参考まで。

--- a/samples/git-harvest-default.sh
+++ b/samples/git-harvest-default.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+#
+# git-harvest "default" の削除挙動だけを切り出した最小・自己完結スクリプト。
+#
+# 削除するもの:
+#   - worktree: merge済 かつ clean なものだけ
+#   - branch:   独自コミットが base にある（merge済 / untouched）もの
+# 保護するもの（invariant）:
+#   - main/default-branch の worktree・カレント worktree(cwd)・locked・走行中 Claude session
+#   - base branch・現在 HEAD・生存 worktree に checkout 中の branch
+#   - untouched な worktree（base と同一で未着手 = 使うために作った checkout なので残す）
+#
+# これは削除コアのみ。本家 git-harvest の dry-run / 色 / --help / 個別 flag /
+# 出力整形 / fail-safe 集計などは載っていない。会社などで個人ライブラリに依存せず
+# 同じ掃除をしたい時のコピペ用リファレンス。
+set -euo pipefail
+
+# --- base（default branch）を fail-closed で解決 ---------------------------
+resolve_base() {
+  local b
+  b=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||')
+  if [ -z "$b" ]; then
+    git -c http.connectTimeout=3 remote set-head origin --auto >/dev/null 2>&1 || true
+    b=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||')
+  fi
+  [ -n "$b" ] || {
+    echo "git-harvest: cannot determine default branch (try: git remote set-head origin <branch>)" >&2
+    exit 1
+  }
+  echo "$b"
+}
+
+# パスを canonical 化（symlink 解決。例 macOS /var -> /private/var）
+canonical_path() { [ -d "$1" ] && (cd "$1" 2>/dev/null && pwd -P) || echo "$1"; }
+
+# worktree に未コミットの変更があるか（0 = dirty）
+has_uncommitted_changes() {
+  local wt="$1"
+  git -C "$wt" diff --quiet HEAD 2>/dev/null || return 0
+  git -C "$wt" diff --quiet --cached 2>/dev/null || return 0
+  [ -n "$(git -C "$wt" ls-files --others --exclude-standard 2>/dev/null)" ] && return 0
+  return 1
+}
+
+# worktree が git worktree lock されているか（0 = locked）
+is_locked_worktree() {
+  git worktree list --porcelain | awk -v t="$1" '
+    /^worktree / { cur = substr($0, 10) }
+    /^locked/    { if (cur == t) f = 1 }
+    END          { exit f ? 0 : 1 }'
+}
+
+# この worktree で走行中の Claude session があるか（0 = あり）
+has_running_claude_session() {
+  local wt="$1" dir="${GIT_HARVEST_CLAUDE_SESSIONS_DIR:-$HOME/.claude/sessions}" wtc f cwd pid
+  [ -d "$dir" ] || return 1
+  wtc=$(canonical_path "$wt")
+  for f in "$dir"/*.json; do
+    [ -f "$f" ] || continue
+    cwd=$(sed -nE 's/.*"cwd"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/p' "$f" | head -1)
+    [ "$(canonical_path "$cwd")" = "$wtc" ] || continue
+    pid=$(sed -nE 's/.*"pid"[[:space:]]*:[[:space:]]*([0-9]+).*/\1/p' "$f" | head -1)
+    [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null && return 0
+  done
+  return 1
+}
+
+# branch を base に対して分類する: untouched / merged / other。
+# 4 段階フォールバック（first-parent / ancestor / 仮想 squash / cherry-pick）。
+#   untouched = 独自コミットなし（HEAD が base の first-parent 線上）
+#   merged    = 内容が base に取り込み済み（ancestor / squash / cherry-pick）
+#   other     = base に未取り込みの独自コミットあり
+classify_branch() {
+  local base="$1" branch="$2" head mb squash cherry
+  head=$(git rev-parse "$branch" 2>/dev/null) || { echo other; return; }
+  if git rev-list --first-parent "$base" 2>/dev/null | grep -qx "$head"; then echo untouched; return; fi
+  if git merge-base --is-ancestor "$branch" "$base" 2>/dev/null; then echo merged; return; fi
+  mb=$(git merge-base "$base" "$branch" 2>/dev/null) || true
+  if [ -n "$mb" ]; then
+    squash=$(git commit-tree "$branch^{tree}" -p "$mb" -m _ 2>/dev/null) || true
+    cherry=$(git cherry "$base" "$squash" 2>/dev/null) || true
+    [ -n "$cherry" ] && [ "$(printf '%s\n' "$cherry" | grep -c '^+')" -eq 0 ] && { echo merged; return; }
+  fi
+  [ -z "$(git log --cherry-pick --right-only --no-merges --oneline "$base...$branch" 2>/dev/null)" ] && { echo merged; return; }
+  echo other
+}
+
+base=$(resolve_base)
+main_wt=$(git worktree list --porcelain | grep --color=never -m1 '^worktree ' | sed 's/^worktree //')
+current_wt=$(canonical_path "$(git rev-parse --show-toplevel 2>/dev/null || pwd)")
+
+# 1) worktree: merge済 かつ clean だけ削除（untouched / 未マージ / dirty は残す）
+while read -r wt; do
+  [ "$wt" = "$main_wt" ] && continue
+  [ "$(canonical_path "$wt")" = "$current_wt" ] && continue
+  branch=$(git -C "$wt" symbolic-ref --short -q HEAD) || continue   # detached は残す
+  [ "$branch" = "$base" ] && continue
+  is_locked_worktree "$wt" && continue
+  has_running_claude_session "$wt" && continue
+  has_uncommitted_changes "$wt" && continue
+  [ "$(classify_branch "$base" "$branch")" = merged ] || continue   # untouched/other は残す
+  git worktree remove "$wt" && echo "removed worktree: $wt" || echo "skip worktree: $wt" >&2
+done < <(git worktree list --porcelain | grep --color=never '^worktree ' | sed 's/^worktree //')
+git worktree prune
+
+# 2) branch: base にある（merged/untouched）だけ削除。worktree を取り直して checkout 判定
+current_head=$(git symbolic-ref --short -q HEAD || true)
+while read -r branch; do
+  [ -z "$branch" ] && continue
+  [ "$branch" = "$base" ] && continue
+  [ "$branch" = "$current_head" ] && continue
+  git worktree list --porcelain | grep -qx "branch refs/heads/$branch" && continue
+  [ "$(classify_branch "$base" "$branch")" != other ] || continue
+  git branch -D "$branch" >/dev/null 2>&1 && echo "removed branch: $branch" || echo "skip branch: $branch" >&2
+done < <(git branch --format='%(refname:short)')

--- a/samples/git-harvest-yolo.sh
+++ b/samples/git-harvest-yolo.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+#
+# git-harvest "--yolo" の削除挙動だけを切り出した最小・自己完結スクリプト。
+#
+# invariant 以外を全部消す（stage 問わず・未コミット込み）:
+#   - worktree: main/default-branch・カレント worktree(cwd)・locked・走行中 Claude session 以外を force 削除
+#   - branch:   base・現在 HEAD・生存 worktree に checkout 中 以外を -D 削除
+#
+# 危険: 未コミット変更も未マージ commit も確認なしで消える。
+# 本家 git-harvest の --yolo は非対話/hook では --yes 必須・件数警告などの安全弁が付くが、
+# これは削除コアのみ。実行前に対象をよく確認すること。
+set -euo pipefail
+
+# --- base（default branch）を fail-closed で解決 ---------------------------
+resolve_base() {
+  local b
+  b=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||')
+  if [ -z "$b" ]; then
+    git -c http.connectTimeout=3 remote set-head origin --auto >/dev/null 2>&1 || true
+    b=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||')
+  fi
+  [ -n "$b" ] || {
+    echo "git-harvest: cannot determine default branch (try: git remote set-head origin <branch>)" >&2
+    exit 1
+  }
+  echo "$b"
+}
+
+canonical_path() { [ -d "$1" ] && (cd "$1" 2>/dev/null && pwd -P) || echo "$1"; }
+
+is_locked_worktree() {
+  git worktree list --porcelain | awk -v t="$1" '
+    /^worktree / { cur = substr($0, 10) }
+    /^locked/    { if (cur == t) f = 1 }
+    END          { exit f ? 0 : 1 }'
+}
+
+has_running_claude_session() {
+  local wt="$1" dir="${GIT_HARVEST_CLAUDE_SESSIONS_DIR:-$HOME/.claude/sessions}" wtc f cwd pid
+  [ -d "$dir" ] || return 1
+  wtc=$(canonical_path "$wt")
+  for f in "$dir"/*.json; do
+    [ -f "$f" ] || continue
+    cwd=$(sed -nE 's/.*"cwd"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/p' "$f" | head -1)
+    [ "$(canonical_path "$cwd")" = "$wtc" ] || continue
+    pid=$(sed -nE 's/.*"pid"[[:space:]]*:[[:space:]]*([0-9]+).*/\1/p' "$f" | head -1)
+    [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null && return 0
+  done
+  return 1
+}
+
+base=$(resolve_base)
+main_wt=$(git worktree list --porcelain | grep --color=never -m1 '^worktree ' | sed 's/^worktree //')
+current_wt=$(canonical_path "$(git rev-parse --show-toplevel 2>/dev/null || pwd)")
+
+# 1) worktree: invariant 以外を force 削除（detached / dirty / 未マージ も問答無用）
+while read -r wt; do
+  [ "$wt" = "$main_wt" ] && continue
+  [ "$(canonical_path "$wt")" = "$current_wt" ] && continue
+  branch=$(git -C "$wt" symbolic-ref --short -q HEAD || true)
+  [ -n "$branch" ] && [ "$branch" = "$base" ] && continue
+  is_locked_worktree "$wt" && continue
+  has_running_claude_session "$wt" && continue
+  git worktree remove --force "$wt" && echo "removed worktree: $wt" || echo "skip worktree: $wt" >&2
+done < <(git worktree list --porcelain | grep --color=never '^worktree ' | sed 's/^worktree //')
+git worktree prune
+
+# 2) branch: base / 現在 HEAD / 生存 worktree が参照中 以外を全削除
+current_head=$(git symbolic-ref --short -q HEAD || true)
+while read -r branch; do
+  [ -z "$branch" ] && continue
+  [ "$branch" = "$base" ] && continue
+  [ "$branch" = "$current_head" ] && continue
+  git worktree list --porcelain | grep -qx "branch refs/heads/$branch" && continue
+  git branch -D "$branch" >/dev/null 2>&1 && echo "removed branch: $branch" || echo "skip branch: $branch" >&2
+done < <(git branch --format='%(refname:short)')


### PR DESCRIPTION
## 概要

git-harvest の `default` と `--yolo` の「削除挙動だけ」を切り出した、単体で動く shell スクリプトのサンプルです。`samples/` に置いています。

意図: 個人ライブラリ（git-harvest）に依存しづらい環境（会社など）でも同じ掃除をしたいときに、1 ファイルをコピペして使えるリファレンスを記録に残すこと。

このPRはマージしません（参照用に残して close します）。

## 中身（throwaway repo で動作確認済み）

| file | 役割 | 行数 |
|---|---|---|
| `samples/git-harvest-default.sh` | merge済 worktree（clean）と base にある branch だけ削除 | 115 行（実質 79 行） |
| `samples/git-harvest-yolo.sh` | invariant 以外を全削除（未コミット込み、force） | 76 行（実質 55 行） |

挙動は今の設計（[issue #169](https://github.com/nozomiishii/git-harvest/issues/169)）の default / `--yolo` に準拠:

- default: merge済 worktree（clean）/ base にある branch を削除。main/default・カレント worktree(cwd)・locked・走行中 session・base・現在 HEAD・checkout 中 branch・untouched worktree は保護
- --yolo: invariant 以外を未コミット込みで force 削除（危険）

base は `origin/HEAD` から fail-closed で解決。削除コアのみで、dry-run / 色 / `--help` / 個別 flag / 出力整形 / fail-safe 集計などは含みません（本家に乗ると倍以上の規模になります）。

## アイデア（未実装・参考）

`git harvest eject --yolo` のように本体から「その preset 相当の単体スクリプト」を吐き出せると、こういうコピペ用ファイルを手で保守せずに済むかもしれません。
