### PR TITLE
chore: extract brand color section into docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,22 +24,4 @@
 
 ## ブランドカラー
 
-`#C0FF39` — Inabikari（rgb 192, 255, 57）
-
-「稲光」: 古くから「雷光が稲を実らせる（稲の成長を促す）」と信じられていたことに由来しており、「稲妻」とほぼ同じ意味
-
-- C = Crop（branch も worktree も harvest 対象）
-- 0 → FF = 育ち始めから育ちきるまでな感じ
-- 39 = サンクス！収穫！
-
-メモ:
-- コード内では「稲光」や「Inabikari」の名前は使わず `BRAND_COLOR` / `ブランドカラー` にする
-- 使用箇所
-    - wordmark `git harvest`
-    - `✓` 成功マーカー
-    - `→` will-delete マーカー
-    - `logo` subcommand
-- `·` 削除せず保護 と reason 文は dim gray
-- エラーは terminal default red を維持して CLI 規約（red=error / yellow=warn）と衝突させない
-- light terminal での視認性は犠牲にして(ごめん) dark terminal 前提（`#C0FF39` は L≈0.83 なので白背景では飛ぶ）
-- `NO_COLOR=1` と 非 TTY ではプレーンテキスト fallback
+定義・由来・使用箇所は [docs/brand-color.md](docs/brand-color.md) を参照。

--- a/docs/brand-color.md
+++ b/docs/brand-color.md
@@ -1,0 +1,21 @@
+# ブランドカラー
+
+`#C0FF39` — Inabikari（rgb 192, 255, 57）
+
+「稲光」: 古くから「雷光が稲を実らせる（稲の成長を促す）」と信じられていたことに由来しており、「稲妻」とほぼ同じ意味
+
+- C = Crop（branch も worktree も harvest 対象）
+- 0 → FF = 育ち始めから育ちきるまでな感じ
+- 39 = サンクス！収穫！
+
+メモ:
+- コード内では「稲光」や「Inabikari」の名前は使わず `BRAND_COLOR` / `ブランドカラー` にする
+- 使用箇所
+    - wordmark `git harvest`
+    - `✓` 成功マーカー
+    - `→` will-delete マーカー
+    - `logo` subcommand
+- `·` 削除せず保護 と reason 文は dim gray
+- エラーは terminal default red を維持して CLI 規約（red=error / yellow=warn）と衝突させない
+- light terminal での視認性は犠牲にして(ごめん) dark terminal 前提（`#C0FF39` は L≈0.83 なので白背景では飛ぶ）
+- `NO_COLOR=1` と 非 TTY ではプレーンテキスト fallback


### PR DESCRIPTION
## 概要
CLAUDE.md のブランドカラーセクションを `docs/brand-color.md` に切り出し、CLAUDE.md からはリンクで参照する。

## 背景
ブランドカラーの由来・使用箇所メモは分量があり、CLAUDE.md（AI 向けの運用指示）の本筋から外れる。docs に独立させて CLAUDE.md を簡潔に保つ。

## 変更
- `docs/brand-color.md` を新規追加（文面はそのまま移植）
- `CLAUDE.md` の該当セクションを見出し + `[docs/brand-color.md](docs/brand-color.md)` のリンクに置き換え