### PR TITLE
chore: prototype eject -- approach B (shell single source)

### DIFF
--- a/experiments/approach-b-shell-core/README.md
+++ b/experiments/approach-b-shell-core/README.md
@@ -1,0 +1,45 @@
+# Approach B — shell as the single source of truth
+
+Prototype for the `eject` discussion ([#138](https://github.com/nozomiishii/git-harvest/issues/138), [#169](https://github.com/nozomiishii/git-harvest/issues/169)). Paired with approach A (`proto/eject-ts`). Self-contained, off `main`, not for merge.
+
+## Idea
+
+One POSIX shell script, `git-harvest.sh`, is the entire implementation. The JS layer (`bin.mjs`, ~20 lines, no dependencies) only:
+
+- runs the script, forwarding flags verbatim, or
+- ejects it — copies the exact script that runs.
+
+So `eject` has perfect fidelity: the ejected artifact IS the runtime, and it needs only `sh` + `git` (zero runtime deps).
+
+## Scope (prototype)
+
+Three cases: `default` / `--worktree-committed` / `--yolo`.
+
+- merged detection: real merge (ancestor) + squash (virtual squash commit + `git cherry`)
+- invariants kept: main worktree, current worktree, base branch, current HEAD
+
+Omitted to stay small (the real tool has these): running-session / locked protection, `.claude/worktrees/` scope, detached / untouched flags, dry-run, multi-OS session paths, cherry-pick (orphan) merge fallback.
+
+## Run
+
+```sh
+node bin.mjs                     # default: remove merged worktrees + branches
+node bin.mjs --worktree-committed
+node bin.mjs --yolo
+node bin.mjs eject ./git-harvest.sh   # copy the standalone script out
+sh test.sh                       # behavioral test on a fixture repo
+```
+
+## Trade-offs
+
+Gains
+- one implementation, no sync tax between TS and shell
+- `eject` equals the runtime — perfect fidelity, and a dependency-free standalone artifact for strict environments
+- the JS layer is tiny; nicer flag/help UX (citty etc.) could sit on top, but is optional
+
+Costs
+- no type safety; the descriptor / `tsc` exhaustiveness from the TS tool is gone
+- the fragile parsing lives in shell. Note `awk '{sub(/^worktree /,"")}'` instead of `$2` so worktree paths with spaces survive; session-JSON reading (omitted here) is the brittle part
+- tests are behavioral only (`test.sh` against a fixture); no fast, precise typed unit tests
+- flag parsing belongs to the shell (so the ejected script is standalone), so a TS/citty layer can't own flags without duplicating them
+- this reverses the direction of [#180](https://github.com/nozomiishii/git-harvest/pull/180), which moved the implementation into TS for testability/maintainability

--- a/experiments/approach-b-shell-core/bin.mjs
+++ b/experiments/approach-b-shell-core/bin.mjs
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+// approach B: the shell script is the single source of truth.
+// This JS layer is intentionally thin and dependency-free. It either
+//   (a) runs the shell, forwarding flags verbatim, or
+//   (b) ejects it — copies the exact script that runs, so the ejected
+//       artifact has perfect fidelity (it IS the runtime).
+//
+// In the real tool this layer is where nicer flag/help UX (e.g. citty) would
+// live; kept as plain ESM here to show how little the JS side needs to carry.
+import { spawnSync } from 'node:child_process';
+import { chmodSync, copyFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const script = join(here, 'git-harvest.sh');
+const argv = process.argv.slice(2);
+
+if (argv[0] === 'eject') {
+  const dest = argv[1] ?? join(process.cwd(), 'git-harvest.sh');
+  copyFileSync(script, dest);
+  chmodSync(dest, 0o755);
+  console.log(`ejected: ${dest}`);
+  process.exit(0);
+}
+
+const r = spawnSync('sh', [script, ...argv], { stdio: 'inherit' });
+process.exit(r.status ?? 1);

--- a/experiments/approach-b-shell-core/git-harvest.sh
+++ b/experiments/approach-b-shell-core/git-harvest.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env sh
+# git-harvest (approach B prototype): the single source of truth.
+# Handles three cases only: default / --worktree-committed / --yolo.
+# The JS layer (bin.mjs) just runs this, or ejects (copies) it verbatim.
+#
+# Out of scope for this prototype (documented in README): running-session /
+# locked protection, .claude/worktrees scope, detached / untouched flags,
+# dry-run, multi-OS session paths, cherry-pick (orphan) merge fallback.
+set -eu
+
+mode=merged   # worktree threshold: merged (default) | committed
+yolo=0
+for arg in "$@"; do
+  case "$arg" in
+    --worktree-committed) mode=committed ;;
+    --yolo) yolo=1 ;;
+    -h | --help)
+      echo "usage: git-harvest [--worktree-committed | --yolo]"
+      exit 0
+      ;;
+    *)
+      echo "git-harvest: unknown option: $arg" >&2
+      exit 2
+      ;;
+  esac
+done
+
+base=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||')
+if [ -z "$base" ]; then
+  echo "git-harvest: cannot determine default branch" >&2
+  exit 1
+fi
+main_wt=$(git worktree list --porcelain | awk '/^worktree /{sub(/^worktree /,""); print; exit}')
+cur_wt=$(cd "$(git rev-parse --show-toplevel)" && pwd -P)
+cur_head=$(git symbolic-ref --short HEAD 2>/dev/null || echo "")
+
+# merged? real merge (ancestor) OR squash (virtual squash commit + git cherry).
+is_merged() {
+  b=$1
+  if git merge-base --is-ancestor "$b" "$base" 2>/dev/null; then return 0; fi
+  mb=$(git merge-base "$base" "$b" 2>/dev/null) || return 1
+  sq=$(git commit-tree "$b^{tree}" -p "$mb" -m _ 2>/dev/null) || return 1
+  if git cherry "$base" "$sq" 2>/dev/null | grep -q '^+'; then return 1; fi
+  return 0
+}
+
+# worktrees. sub() (not $2) preserves paths containing spaces.
+git worktree list --porcelain | awk '/^worktree /{sub(/^worktree /,""); print}' | while IFS= read -r wt; do
+  if [ "$wt" = "$main_wt" ]; then continue; fi
+  wtc=$(cd "$wt" 2>/dev/null && pwd -P) || continue
+  if [ "$wtc" = "$cur_wt" ]; then continue; fi
+  br=$(git -C "$wt" symbolic-ref --short HEAD 2>/dev/null || echo "")
+  if [ "$br" = "$base" ]; then continue; fi
+
+  if [ "$yolo" = 1 ]; then
+    if git worktree remove --force "$wt" 2>/dev/null; then echo "removed worktree: $wt"; fi
+    continue
+  fi
+  if [ -z "$br" ]; then continue; fi # detached: kept in this prototype
+
+  if is_merged "$br"; then
+    if git worktree remove "$wt" 2>/dev/null; then echo "removed worktree: $wt"; fi
+  elif [ "$mode" = committed ]; then
+    if git worktree remove --force "$wt" 2>/dev/null; then echo "removed worktree: $wt"; fi
+  fi
+done
+
+# branches. base and current HEAD are kept. merged on default; everything on --yolo.
+git branch --format='%(refname:short)' | while IFS= read -r b; do
+  if [ "$b" = "$base" ]; then continue; fi
+  if [ "$b" = "$cur_head" ]; then continue; fi
+
+  if [ "$yolo" = 1 ]; then
+    if git branch -D "$b" >/dev/null 2>&1; then echo "removed branch: $b"; fi
+  elif is_merged "$b"; then
+    if git branch -D "$b" >/dev/null 2>&1; then echo "removed branch: $b"; fi
+  fi
+done

--- a/experiments/approach-b-shell-core/test.sh
+++ b/experiments/approach-b-shell-core/test.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env sh
+# Behavioral test for approach B: build a real fixture repo, run the single
+# source-of-truth shell, assert end state. This is the only test layer the
+# shell-source approach gets (no typed unit tests).
+set -eu
+here=$(cd "$(dirname "$0")" && pwd)
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+gh() { sh "$here/git-harvest.sh" "$@" >/dev/null; }
+has_branch() { git show-ref --verify --quiet "refs/heads/$1"; }
+fail() {
+  echo "FAIL: $1"
+  exit 1
+}
+
+# origin + clone so origin/HEAD resolves like a real checkout.
+git init -q --bare "$tmp/origin.git"
+git clone -q "$tmp/origin.git" "$tmp/repo"
+cd "$tmp/repo"
+git config user.email t@t.t
+git config user.name t
+git config commit.gpgsign false
+echo a > a
+git add a
+git commit -qm init
+git push -q origin HEAD:main
+git remote set-head origin main
+git branch -m main
+
+# feat-merged: squash-merged into main (content is in base).
+git checkout -qb feat-merged
+echo b > b
+git add b
+git commit -qm work
+git checkout -q main
+git merge -q --squash feat-merged
+git commit -qm squash
+git push -q
+# feat-open: real unmerged commits.
+git checkout -qb feat-open
+echo c > c
+git add c
+git commit -qm open
+git checkout -q main
+git worktree add -q "$tmp/wt-merged" feat-merged
+git worktree add -q "$tmp/wt-open" feat-open
+
+# default: merged worktree + merged branch go; the open ones stay.
+gh
+has_branch feat-merged && fail "default kept merged branch"
+has_branch feat-open || fail "default deleted the unmerged branch"
+[ -d "$tmp/wt-open" ] || fail "default deleted the unmerged worktree"
+echo "PASS: default removes only merged"
+
+# --worktree-committed: lowers the worktree threshold; the open worktree goes,
+# but the open branch (not merged) stays — branch threshold is unchanged.
+gh --worktree-committed
+[ -d "$tmp/wt-open" ] && fail "--worktree-committed kept the committed worktree"
+has_branch feat-open || fail "--worktree-committed wrongly deleted the open branch"
+echo "PASS: --worktree-committed removes the committed worktree, keeps its branch"
+
+# --yolo: everything non-invariant goes.
+gh --yolo
+has_branch feat-open && fail "--yolo kept the open branch"
+echo "PASS: --yolo removes everything left"
+
+echo "ALL PASS"


### PR DESCRIPTION
案B のプロトタイプ。`eject` 議論（#138 / #169）の比較用。案A（`proto/eject-ts`）とペア。`main` から切った self-contained な追加のみで、マージ対象ではない。

## 方針

POSIX shell 1本（`git-harvest.sh`）が実装の全て。JS 層（`bin.mjs`、約20行・依存ゼロ）は「走らせる」か「eject（コピー）」だけ。eject した成果物は実行物そのもので、`sh` + `git` だけで動く（ランタイム依存ゼロ）。

## スコープ

`default` / `--worktree-committed` / `--yolo` の3ケース。merged 判定は real + squash。invariant は main worktree・current worktree・base branch・current HEAD。

session/locked 保護・`.claude/worktrees/` scope・detached/untouched・dry-run・多OS・cherry-pick fallback は小さく保つため省略（README 参照）。

## 動かす

```sh
node bin.mjs
node bin.mjs --worktree-committed
node bin.mjs --yolo
node bin.mjs eject ./git-harvest.sh
sh test.sh   # fixture repo に対する振る舞いテスト（ローカルで ALL PASS 確認済み）
```

## トレードオフ（要点）

- 単一実装で同期税なし、eject = 実行物で完全 fidelity、依存ゼロの standalone
- 型安全なし、繊細なパースが shell（path のスペースは `awk sub()` で回避済み・session JSON が脆い所）
- テストは振る舞いのみ（`test.sh`）、高速な型付き unit はなし
- flag parse を shell が持つので citty 等の TS 層と二重になりがち
- #180 の「実装を TS に寄せた」方向を戻すことになる

詳細は `experiments/approach-b-shell-core/README.md`。
