### PR TITLE
chore: self-heal release PR lockfile drift via always-update

### DIFF
--- a/.github/.release-please-config.json
+++ b/.github/.release-please-config.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "bootstrap-sha": "302ed82827bc9f8c52e49ac70a32e5b5b8dc4270",
+  "always-update": true,
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
   "include-component-in-tag": false,


### PR DESCRIPTION
## 概要

release PR (`chore: release X.Y.Z`) の CI が lockfile 不整合で落ちる問題への予防対処。[nozomiishii/configs#2400](https://github.com/nozomiishii/configs/pull/2400) の横展開。このリポジトリではまだ実害は確認していないが、構成上 configs と同じ TOCTOU を踏みうるため予防的に入れる。

## 原因 (release-please の TOCTOU)

release-please は `package.json` を読む時刻と、commit の base_tree を解決する時刻に SHA pinning が無い。release run の最中に renovate の依存 PR が main へ merge されると、`package.json` は古い読込結果のまま version bump されるのに、`bun.lock` は後の main 由来のまま残り乖離する。結果 `bun install --frozen-lockfile` が落ち、release PR の CI が連鎖失敗する。

release-please は node strategy で npm の `package-lock.json` しか更新せず、`bun.lock` / `pnpm-lock.yaml` / `yarn.lock` は管理対象外。さらに version + changelog が一致する限り PR を更新しないため、この乖離を自己修復しない。

## 対応

`.github/.release-please-config.json` に `always-update: true` を追加。release notes が変わらなくても後続の release run が release PR を最新 main へ再生成し直すので、乖離が自己修復する。

- 公式ドキュメント (Configfile): <https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md#configfile>
- 追加 PR: <https://github.com/googleapis/release-please/pull/1459>