### PR TITLE
chore: add lint troubleshooting guide reference to eslint config

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -5,7 +5,10 @@ import { defineConfig, node } from "@nozomiishii/eslint-config";
 export default defineConfig([
   ...node(),
 
+  // エラーの解決手順や、よくある対応パターンはこちらにまとめています:
+  // https://github.com/nozomiishii/configs/blob/main/packages/eslint-config/docs/troubleshooting.md
   {
+    name: "project/overrides",
     rules: {
       // test は execSync(bash) で子プロセスに env を渡すため、必要な変数だけ process.env から読む
       "n/no-process-env": ["error", { allowedVariables: ["HOME", "PATH"] }],


### PR DESCRIPTION
## 概要

`@nozomiishii/eslint-config` の troubleshooting ガイド（nozomiishii/configs#2411）に合わせ、eslint.config.ts にガイドへの誘導コメントを追加し、既存の override ブロックを `project/overrides` と命名する。

## 変更

- `eslint.config.ts` … 誘導コメント追加＋既存ブロックを命名。既存の `n/no-process-env` ルールはそのまま。
