### PR TITLE
chore: pin 1password/load-secrets-action to semver tag

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,7 +35,7 @@ jobs:
     steps:
       - name: Load secrets from 1Password
         id: secrets
-        uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4
+        uses: 1password/load-secrets-action@3a12b0ab99d9cd590a3e9b5a90ea017210ed9556 # v4.0.1
         with:
           # renovate: datasource=docker depName=1password/op versioning=semver
           version: "2.34.0"
@@ -170,7 +170,7 @@ jobs:
     steps:
       - name: Load secrets from 1Password
         id: secrets
-        uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4
+        uses: 1password/load-secrets-action@3a12b0ab99d9cd590a3e9b5a90ea017210ed9556 # v4.0.1
         with:
           # renovate: datasource=docker depName=1password/op versioning=semver
           version: "2.34.0"


### PR DESCRIPTION
## 背景

[nozomiishii/renovate#626](https://github.com/nozomiishii/renovate/pull/626) で `helpers:pinGitHubActionDigestsToSemver` を導入したが、本 repo の `1password/load-secrets-action` は `# v4` のままで preset の semver pin enforce が効いていなかった。

その結果 #205 のような digest-only PR が生成された（`v4` movable tag が v4.0.1 に再ポイントされたことを `# v4` 表記で読み取れない）。

## 変更内容

release.yaml の 2 箇所を v4.0.1 で固定:

- digest: `92467eb` → `3a12b0a`
- コメント: `# v4` → `# v4.0.1`

これで `helpers:pinGitHubActionDigestsToSemver` の `extractVersion` が効き、以降は semver tag のみが Renovate の追跡対象になる。

## 関連

- supersedes #205（重複なので close）

## テスト

CI に任せる。