### PR TITLE
chore: take dryRun/enabled as one object in remove helpers

### DIFF
--- a/lib/branch.ts
+++ b/lib/branch.ts
@@ -53,7 +53,11 @@ export async function cleanupBranches(
       }
 
       results.push(
-        await removeCommittedBranch(name, flags.committed.includes("branch"), flags.dryRun, opts),
+        await removeCommittedBranch(
+          name,
+          { dryRun: flags.dryRun, enabled: flags.committed.includes("branch") },
+          opts,
+        ),
       );
     } catch (error) {
       // 1 件の throw（壊れた ref 等）で全体を止めない
@@ -115,15 +119,14 @@ async function removeBranch(name: string, opts: Opts): Promise<BranchActionResul
 // committed の branch は committed の対象に branch が入っていれば消す、なければ理由付きで残す
 async function removeCommittedBranch(
   name: string,
-  isTarget: boolean,
-  dryRun: boolean,
+  args: { dryRun: boolean; enabled: boolean },
   opts: Opts,
 ): Promise<BranchActionResult> {
-  if (!isTarget) {
+  if (!args.enabled) {
     return { action: "kept", message: "committed", name };
   }
 
-  if (dryRun) {
+  if (args.dryRun) {
     return { action: "would-remove", name };
   }
 

--- a/lib/worktree.test.ts
+++ b/lib/worktree.test.ts
@@ -54,7 +54,7 @@ test("removeMerged marks a merged worktree for removal", async () => {
 test("removeCommitted keeps a committed worktree without the committed flag", async () => {
   const worktree = wtRecord();
 
-  const result = await removeCommitted(worktree, false, true, {});
+  const result = await removeCommitted(worktree, { dryRun: true, enabled: false }, {});
 
   expect(result).toStrictEqual({
     action: "kept",
@@ -68,7 +68,7 @@ test("removeCommitted keeps a committed worktree without the committed flag", as
 test("removeCommitted marks a committed worktree for removal with the committed flag", async () => {
   const worktree = wtRecord();
 
-  const result = await removeCommitted(worktree, true, true, {});
+  const result = await removeCommitted(worktree, { dryRun: true, enabled: true }, {});
 
   expect(result).toStrictEqual({ action: "would-remove", branch: "feature", path: worktree.path });
 });
@@ -77,7 +77,7 @@ test("removeCommitted marks a committed worktree for removal with the committed 
 test("removeFilesChanged keeps a files-changed worktree without the files-changed flag", async () => {
   const worktree = wtRecord();
 
-  const result = await removeFilesChanged(worktree, false, true, {});
+  const result = await removeFilesChanged(worktree, { dryRun: true, enabled: false }, {});
 
   expect(result).toStrictEqual({
     action: "kept",
@@ -91,7 +91,7 @@ test("removeFilesChanged keeps a files-changed worktree without the files-change
 test("removeUntouched keeps an untouched worktree without the flag", async () => {
   const worktree = wtRecord();
 
-  const result = await removeUntouched(worktree, false, true, {});
+  const result = await removeUntouched(worktree, { dryRun: true, enabled: false }, {});
 
   expect(result).toStrictEqual({
     action: "kept",
@@ -105,7 +105,7 @@ test("removeUntouched keeps an untouched worktree without the flag", async () =>
 test("removeUntouched marks an untouched worktree for removal with the flag", async () => {
   const worktree = wtRecord();
 
-  const result = await removeUntouched(worktree, true, true, {});
+  const result = await removeUntouched(worktree, { dryRun: true, enabled: true }, {});
 
   expect(result).toStrictEqual({ action: "would-remove", branch: "feature", path: worktree.path });
 });
@@ -114,7 +114,7 @@ test("removeUntouched marks an untouched worktree for removal with the flag", as
 test("removeDetached keeps a detached worktree without the flag", async () => {
   const worktree = wtRecord({ branch: undefined });
 
-  const result = await removeDetached(worktree, false, true, {});
+  const result = await removeDetached(worktree, { dryRun: true, enabled: false }, {});
 
   expect(result).toStrictEqual({
     action: "kept",
@@ -128,7 +128,7 @@ test("removeDetached keeps a detached worktree without the flag", async () => {
 test("removeDetached marks a detached worktree for removal with the flag", async () => {
   const worktree = wtRecord({ branch: undefined });
 
-  const result = await removeDetached(worktree, true, true, {});
+  const result = await removeDetached(worktree, { dryRun: true, enabled: true }, {});
 
   expect(result).toStrictEqual({ action: "would-remove", branch: undefined, path: worktree.path });
 });

--- a/lib/worktree.ts
+++ b/lib/worktree.ts
@@ -55,7 +55,7 @@ export async function cleanupWorktrees(
 
       // detached = branch を持たない worktree。off-ladder なので --detached でだけ消す
       if (worktree.branch === undefined) {
-        results.push(await removeDetached(worktree, flags.detached, flags.dryRun, opts));
+        results.push(await removeDetached(worktree, { dryRun: flags.dryRun, enabled: flags.detached }, opts));
         continue;
       }
       // 状態を上から1つずつ判定し、対応する削除関数を即実行する。
@@ -65,13 +65,21 @@ export async function cleanupWorktrees(
 
       // 未コミットの変更が最優先（消すと復元できない）
       if (await hasUncommittedChanges(worktree.path)) {
-        results.push(await removeFilesChanged(worktree, flags.filesChanged.includes(scope), flags.dryRun, opts));
+        results.push(
+          await removeFilesChanged(
+            worktree,
+            { dryRun: flags.dryRun, enabled: flags.filesChanged.includes(scope) },
+            opts,
+          ),
+        );
         continue;
       }
 
       // 独自コミット無し（off-ladder）。--untouched でだけ消す
       if (await isUntouched(refs, opts)) {
-        results.push(await removeUntouched(worktree, flags.untouched, flags.dryRun, opts));
+        results.push(
+          await removeUntouched(worktree, { dryRun: flags.dryRun, enabled: flags.untouched }, opts),
+        );
         continue;
       }
 
@@ -81,7 +89,13 @@ export async function cleanupWorktrees(
       }
 
       // どれでもない = 未マージの独自コミットあり（committed）
-      results.push(await removeCommitted(worktree, committedScopes.has(scope), flags.dryRun, opts));
+      results.push(
+        await removeCommitted(
+          worktree,
+          { dryRun: flags.dryRun, enabled: committedScopes.has(scope) },
+          opts,
+        ),
+      );
     } catch (error) {
       // 1 件の throw（壊れた ref で rev-parse 失敗 等）で全体を止めない
       results.push({ action: "failed", branch: worktree.branch, message: String(error), path: worktree.path });
@@ -121,15 +135,14 @@ export async function listWorktrees(opts: Opts = {}): Promise<WtRecord[]> {
 // committed の worktree。scope が --committed の対象なら消す（force 不要）、無ければ理由付きで残す
 export async function removeCommitted(
   worktree: WtRecord,
-  isTarget: boolean,
-  dryRun: boolean,
+  args: { dryRun: boolean; enabled: boolean },
   opts: Opts,
 ): Promise<WorktreeActionResult> {
-  if (!isTarget) {
+  if (!args.enabled) {
     return { action: "kept", branch: worktree.branch, message: "committed", path: worktree.path };
   }
 
-  if (dryRun) {
+  if (args.dryRun) {
     return { action: "would-remove", branch: worktree.branch, path: worktree.path };
   }
 
@@ -140,15 +153,14 @@ export async function removeCommitted(
 // detached は未コミット変更を持ちうるので、その場合は force（commit を指す参照ごと失われる前提）
 export async function removeDetached(
   worktree: WtRecord,
-  detached: boolean,
-  dryRun: boolean,
+  args: { dryRun: boolean; enabled: boolean },
   opts: Opts = {},
 ): Promise<WorktreeActionResult> {
-  if (!detached) {
+  if (!args.enabled) {
     return { action: "kept", branch: worktree.branch, message: "detached", path: worktree.path };
   }
 
-  if (dryRun) {
+  if (args.dryRun) {
     return { action: "would-remove", branch: worktree.branch, path: worktree.path };
   }
   const dirty = await hasUncommittedChanges(worktree.path);
@@ -159,15 +171,14 @@ export async function removeDetached(
 // files-changed の worktree。scope が --files-changed の対象なら消す（未コミットごと force）、無ければ残す
 export async function removeFilesChanged(
   worktree: WtRecord,
-  isTarget: boolean,
-  dryRun: boolean,
+  args: { dryRun: boolean; enabled: boolean },
   opts: Opts,
 ): Promise<WorktreeActionResult> {
-  if (!isTarget) {
+  if (!args.enabled) {
     return { action: "kept", branch: worktree.branch, message: "files-changed", path: worktree.path };
   }
 
-  if (dryRun) {
+  if (args.dryRun) {
     return { action: "would-remove", branch: worktree.branch, path: worktree.path };
   }
 
@@ -191,15 +202,14 @@ export async function removeMerged(
 // 呼び出し側が hasUncommittedChanges を先に見て clean を確定済みなので force は不要
 export async function removeUntouched(
   worktree: WtRecord,
-  untouched: boolean,
-  dryRun: boolean,
+  args: { dryRun: boolean; enabled: boolean },
   opts: Opts = {},
 ): Promise<WorktreeActionResult> {
-  if (!untouched) {
+  if (!args.enabled) {
     return { action: "kept", branch: worktree.branch, message: "untouched", path: worktree.path };
   }
 
-  if (dryRun) {
+  if (args.dryRun) {
     return { action: "would-remove", branch: worktree.branch, path: worktree.path };
   }
 


### PR DESCRIPTION
## 概要

`removeUntouched` / `removeDetached` / `removeCommitted` / `removeFilesChanged` と `removeCommittedBranch` で `boolean` が 2 つ並んでいたシグネチャを、`args: { dryRun; enabled }` のオブジェクト引数に統合した。

呼び出し側で `flags.untouched` と `flags.dryRun` を取り違えても気づきづらかった問題を、フィールド名で固定して防ぐ。

## 変更点

- `lib/worktree.ts`: `removeUntouched` / `removeDetached` / `removeCommitted` / `removeFilesChanged` のシグネチャを `(worktree, args: { dryRun; enabled }, opts)` に変更
- `lib/branch.ts`: `removeCommittedBranch` を同様にオブジェクト化
- `cleanupWorktrees` / `cleanupBranches` の呼び出しも更新
- `removeMerged` / `removeMergedBranch` は `boolean` 1 つだけで取り違えの恐れが無いので据え置き

## テスト

- `pnpm test` 58/58 passed
- `pnpm tsc --noEmit` クリーン