### PR TITLE
chore: revamp README in a git-trim style

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -14,7 +14,7 @@
 
 branch と worktree を、コミットのライフサイクル段階に応じて自動で整理するツール
 
-## お試し (`--dry-run`)
+## お試し
 
 削除対象を表示するだけで、実際には何も削除しません:
 
@@ -22,42 +22,54 @@ branch と worktree を、コミットのライフサイクル段階に応じて
 npx -y git-harvest@latest --dry-run
 ```
 
-## インストールせずに直接実行 (推奨)
+## セットアップ
 
-常に最新版が走るので、アップデート作業は不要です。
-
-```sh
-# npm
-npx -y git-harvest@latest
-
-# pnpm
-pnpx git-harvest@latest
-
-# bun
-bunx git-harvest@latest
-```
-
-### (任意) エイリアスを設定
+`git harvest` を Git のサブコマンドとして使えるように、alias を登録します。常に最新版が走るので、アップデート作業は不要です。
 
 ```sh
-# 通常 (デフォルト = merged のみ削除)
-echo "alias ghv='npx -y git-harvest@latest'" >> ~/.zshrc
-# 一掃 (--yolo = 未コミット・detached 含めて削除)
-echo "alias 'ghv!'='npx -y git-harvest@latest --yolo'" >> ~/.zshrc
-```
-
-`git harvest`
-
-```sh
-# git サブコマンド — `git harvest` として実行 (インストール不要)
 git config --global alias.harvest '!npx -y git-harvest@latest'
 # または: git config --global alias.harvest '!pnpx git-harvest@latest'
 # または: git config --global alias.harvest '!bunx git-harvest@latest'
 ```
 
-## おすすめの運用法
+## 使い方
 
-Git hooks の post-merge コマンドと合わせると、merge や pull のたびに自動で収穫できます。
+```sh
+git harvest
+# merged な branch を削除 (デフォルト・最も安全。post-merge hook でも安全)
+
+git harvest --dry-run
+git harvest -n
+# 削除せず、削除対象だけ表示
+
+git harvest --committed
+# committed な作業も削除 (未コミットは守る)
+
+git harvest --files-changed
+# 未コミットの worktree も削除 (worktree 系のみ)
+
+git harvest --untouched
+# untouched な worktree も削除 (作業なし・base と同一)
+
+git harvest --detached
+# detached な worktree も削除 (branch 無し)
+# ⚠ detached worktree の commit は復旧不可
+```
+
+組み合わせも可能です。例: `git harvest --committed --untouched` は committed な branch と untouched な worktree をまとめて削除します。
+
+プリセットもあります:
+
+```sh
+git harvest --yolo
+# --files-changed --committed --untouched --detached と等価
+```
+
+`--committed` と `--files-changed` には scope を指定できます: `=worktree` / `=claude-worktree` / `=branch`。省略時は対象の全 scope に効きます。複数指定は comma 区切り (`--committed=worktree,branch`) か、フラグの繰り返しです。
+
+## 自動化 (任意)
+
+`git harvest` を Git の post-merge hook と組み合わせると、merge や pull のたびに自動で収穫できます。
 
 ### [lefthook](https://github.com/evilmartians/lefthook) との連携
 
@@ -72,31 +84,6 @@ post-merge:
       # or: pnpx git-harvest@latest
       # or: bunx git-harvest@latest
 ```
-
-## 使い方
-
-```sh
-npx -y git-harvest@latest
-```
-
-### オプション
-
-```
--h, --help                   ヘルプを表示
--v, --version                バージョンを表示
--n, --dry-run                削除せず、削除対象だけ表示
-
---committed[=<scope>]        閾値を committed へ (committed + merged を削除。未コミットは守る)
---files-changed[=<scope>]    閾値を files-changed へ (未コミット込みで削除。worktree 系のみ)
---untouched                  untouched な worktree も削除 (base と同一・作業なし)
---detached                   detached な worktree も削除 (branch 無し)
-                             ⚠ detached worktree の commit は到達不能で、削除すると恒久的に失われる (reflog でも復旧不可)
---yolo                       プリセット: --files-changed --committed --untouched --detached (全 scope)
-
-logo                         ロゴを表示
-```
-
-`<scope>` は `worktree` / `claude-worktree` / `branch`。省略時は対象の全 scope に効きます。複数指定は comma 区切り (`--committed=worktree,branch`) か、フラグの繰り返しです。`--files-changed` は branch 段を持たないため worktree 系のみです。
 
 ## 動作内容
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ English | [日本語](./README.ja.md)
 
 Clean up branches and worktrees automatically, by their commit lifecycle stage.
 
-## Try it (`--dry-run`)
+## Try it
 
 Shows what would be deleted without deleting anything:
 
@@ -22,46 +22,58 @@ Shows what would be deleted without deleting anything:
 npx -y git-harvest@latest --dry-run
 ```
 
-## Run directly without installing (recommended)
+## Setup
 
-Always runs the latest version, so there is nothing to update.
-
-```sh
-# npm
-npx -y git-harvest@latest
-
-# pnpm
-pnpx git-harvest@latest
-
-# bun
-bunx git-harvest@latest
-```
-
-### (Optional) Set up aliases
+Register `git harvest` as a Git alias so you can call it like a built-in subcommand. The alias runs the latest version on every call, so there is nothing to update.
 
 ```sh
-# normal (default = delete merged only)
-echo "alias ghv='npx -y git-harvest@latest'" >> ~/.zshrc
-# sweep (--yolo = delete uncommitted and detached too)
-echo "alias 'ghv!'='npx -y git-harvest@latest --yolo'" >> ~/.zshrc
-```
-
-`git harvest`
-
-```sh
-# git subcommand — run as `git harvest` (no install)
 git config --global alias.harvest '!npx -y git-harvest@latest'
 # or: git config --global alias.harvest '!pnpx git-harvest@latest'
 # or: git config --global alias.harvest '!bunx git-harvest@latest'
 ```
 
-## Recommended usage
+## Usage
 
-Pair it with a Git post-merge hook to harvest automatically on every merge or pull.
+```sh
+git harvest
+# Removes merged branches (safe default -- safe even in a post-merge hook)
+
+git harvest --dry-run
+git harvest -n
+# Shows what would be deleted without deleting
+
+git harvest --committed
+# Removes committed work too (still keeps uncommitted)
+
+git harvest --files-changed
+# Removes uncommitted worktrees too (worktree scopes only)
+
+git harvest --untouched
+# Also removes untouched worktrees (no work, identical to base)
+
+git harvest --detached
+# Also removes detached worktrees (no branch)
+# WARNING: commits in a detached worktree are unrecoverable
+```
+
+Of course, you can combine these. For example, `git harvest --committed --untouched` removes committed branches plus untouched worktrees.
+
+There is also a preset:
+
+```sh
+git harvest --yolo
+# Equivalent to --files-changed --committed --untouched --detached
+```
+
+The `--committed` and `--files-changed` flags accept an optional scope: `=worktree`, `=claude-worktree`, or `=branch`. Without a scope they apply to all applicable scopes. Combine with commas (`--committed=worktree,branch`) or by repeating the flag.
+
+## Automate (optional)
+
+Pair `git harvest` with a Git post-merge hook to harvest automatically on every merge or pull.
 
 ### With [lefthook](https://github.com/evilmartians/lefthook)
 
-There are many Git Hooks tools (husky, pre-commit, simple-git-hooks), but Lefthook is language-agnostic and easy to drop into a monorepo. With `lefthook-local.yaml` you can run it only for yourself without affecting teammates.
+There are many Git hooks tools (husky, pre-commit, simple-git-hooks), but Lefthook is language-agnostic and easy to drop into a monorepo. With `lefthook-local.yaml` you can run it only for yourself without affecting teammates.
 
 ```yaml
 # lefthook-local.yaml
@@ -72,31 +84,6 @@ post-merge:
       # or: pnpx git-harvest@latest
       # or: bunx git-harvest@latest
 ```
-
-## Usage
-
-```sh
-npx -y git-harvest@latest
-```
-
-### Options
-
-```
--h, --help                   Show help
--v, --version                Show version
--n, --dry-run                Show what would be deleted without deleting
-
---committed[=<scope>]        Lower the threshold to committed (delete committed + merged; keep uncommitted)
---files-changed[=<scope>]    Lower the threshold to files-changed (delete uncommitted too; worktree scopes only)
---untouched                  Also delete untouched worktrees (no work, identical to base)
---detached                   Also delete detached worktrees (no branch)
-                             WARNING: a detached worktree's commits are unreachable -- removal can lose them permanently (no reflog recovery)
---yolo                       Preset: --files-changed --committed --untouched --detached (all scopes)
-
-logo                         Show the logo
-```
-
-`<scope>` is `worktree` / `claude-worktree` / `branch`. When omitted it applies to all applicable scopes. List multiple scopes comma-separated (`--committed=worktree,branch`) or by repeating the flag. `--files-changed` has no branch stage, so it applies to worktree scopes only.
 
 ## How it works
 


### PR DESCRIPTION
## Summary

- README を [git-trim](https://github.com/jasonmccreary/git-trim) 風の構造に再編し、フラグの効き目が一段で読める形に
- ヘッダー直下に「Setup」セクションを置き、`git config --global alias.harvest '!npx -y git-harvest@latest'` 1 行で `git harvest` 化を案内
- Usage は `git harvest ...` 形式のコマンド + 1 行コメントで羅列。組み合わせ・`--yolo`・scope は散文で補足
- 旧「インストール三択 (npm / pnpm / bun)」と「シェル alias (`ghv` / `ghv!`)」セクションは `git alias` で代替できるため削除
- 「How it works」以降の設計解説 (stages / scopes / off-ladder / 判定フロー / Claude Code 連携) はそのまま温存

## Test plan

- [ ] GitHub 上で README.md / README.ja.md のレンダリングを目視確認
- [ ] mermaid 図が壊れていないことを確認
- [ ] 英日で構成が一致していることを確認