### PR TITLE
chore: mark Setup section as optional in READMEs

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -26,9 +26,9 @@ Branches
   →  feature/done
 ```
 
-## セットアップ
+## セットアップ (任意)
 
-`git harvest` を Git のサブコマンドとして使えるように、alias を登録します。常に最新版が走るので、アップデート不要です。
+`npx -y git-harvest@latest` だけでも動きますが、alias を登録すると短く呼べます。常に最新版が走るので、アップデート不要です。
 
 ```sh
 git config --global alias.harvest '!npx -y git-harvest@latest'

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ Branches
   →  feature/done
 ```
 
-## Setup
+## Setup (optional)
 
-Register `git harvest` as a Git alias. It always runs the latest version — nothing to update.
+`npx -y git-harvest@latest` works on its own, but registering a Git alias makes it shorter. It always runs the latest version — nothing to update.
 
 ```sh
 git config --global alias.harvest '!npx -y git-harvest@latest'


### PR DESCRIPTION
## 概要

- Setup セクションに (optional) / (任意) を追加
- `npx -y git-harvest@latest` だけでも動くことを先に明記

## テスト

- [ ] README.md / README.ja.md の Setup セクションが optional であることが伝わる