### PR TITLE
chore: add shell alias example to Setup section

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -30,10 +30,18 @@ Branches
 
 `npx -y git-harvest@latest` だけでも動きますが、alias を登録すると短く呼べます。常に最新版が走るので、アップデート不要です。
 
+Git alias — `git harvest` として呼ぶ:
+
 ```sh
 git config --global alias.harvest '!npx -y git-harvest@latest'
 # または: git config --global alias.harvest '!pnpx git-harvest@latest'
 # または: git config --global alias.harvest '!bunx git-harvest@latest'
+```
+
+Shell alias — `.bashrc` / `.zshrc` に追加:
+
+```sh
+alias ghv='npx -y git-harvest@latest'
 ```
 
 ## 使い方

--- a/README.md
+++ b/README.md
@@ -28,12 +28,20 @@ Branches
 
 ## Setup (optional)
 
-`npx -y git-harvest@latest` works on its own, but registering a Git alias makes it shorter. It always runs the latest version — nothing to update.
+`npx -y git-harvest@latest` works on its own, but an alias makes it shorter. It always runs the latest version — nothing to update.
+
+Git alias — call it as `git harvest`:
 
 ```sh
 git config --global alias.harvest '!npx -y git-harvest@latest'
 # or: git config --global alias.harvest '!pnpx git-harvest@latest'
 # or: git config --global alias.harvest '!bunx git-harvest@latest'
+```
+
+Shell alias — add to `.bashrc` / `.zshrc`:
+
+```sh
+alias ghv='npx -y git-harvest@latest'
 ```
 
 ## Usage


### PR DESCRIPTION
## 概要

Setup セクションに shell alias (`alias ghv='npx -y git-harvest@latest'`) の例を追加。
Git alias と shell alias の 2 パターンを見出しで区別し、好みに応じて選べるようにした。

## テスト

- [ ] README.md / README.ja.md の Setup セクションに Git alias と shell alias の両方が記載されている