### PR TITLE
feat: add required summary gate job with changes detection to test workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,21 +15,22 @@ defaults:
     shell: bash
 
 jobs:
-  test:
+  changes:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 5
     permissions:
       contents: read # required by actions/checkout to fetch repository code and dorny/paths-filter to diff against the base ref
-
+    outputs:
+      src: ${{ steps.filter.outputs.src }}
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
-      - name: Check for changes
+      - name: Detect changes
         uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
-        id: changes
+        id: filter
         with:
           filters: |
             src:
@@ -40,27 +41,47 @@ jobs:
               - 'tsdown.config.ts'
               - 'vitest.config.ts'
 
+  test:
+    needs: changes
+    if: needs.changes.outputs.src == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
       - name: Setup pnpm
-        if: steps.changes.outputs.src == 'true'
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
       - name: Setup Node.js
-        if: steps.changes.outputs.src == 'true'
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: package.json
           cache: pnpm
 
       - name: Install dependencies
-        if: steps.changes.outputs.src == 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Run tests
-        if: steps.changes.outputs.src == 'true'
         run: pnpm test
 
       - name: Build and smoke-test the CLI
-        if: steps.changes.outputs.src == 'true'
         run: |
           pnpm build
           node dist/cli.mjs --version
+
+  required:
+    needs: [changes, test]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - name: Fail if any required job failed or was cancelled
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: |
+          echo "A required job failed or was cancelled"
+          exit 1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,7 +16,7 @@ defaults:
 
 jobs:
   changes:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     timeout-minutes: 5
     permissions:
       contents: read # required by actions/checkout to fetch repository code and dorny/paths-filter to diff against the base ref
@@ -77,7 +77,7 @@ jobs:
   required:
     needs: [changes, test]
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     timeout-minutes: 1
     steps:
       - name: Fail if any required job failed or was cancelled

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,16 +21,15 @@ jobs:
     permissions:
       contents: read # required by actions/checkout to fetch repository code and dorny/paths-filter to diff against the base ref
     outputs:
-      src: ${{ steps.filter.outputs.src }}
+      src: ${{ steps.changes.outputs.src }}
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
-      - name: Detect changes
-        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
-        id: filter
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: changes
         with:
           filters: |
             src:


### PR DESCRIPTION
## 概要

テストワークフローを3ジョブ構成にリファクタリング。

- `changes`: パス変更検出を独立ジョブとして分離
- `test`: 変更検出結果に応じて条件実行
- `required`: 全必須ジョブの成否をまとめるゲートジョブを追加

GitHub の branch protection で `required` ジョブを必須ステータスチェックに設定することで、変更がない場合でもマージ可能になる。

## テスト計画

- [ ] 関連ファイルを変更した PR で `changes` → `test` → `required` の順に実行されることを確認
- [ ] 関連ファイルの変更がない PR で `test` がスキップされ `required` が成功することを確認
- [ ] `test` が失敗した場合に `required` も失敗することを確認

https://claude.ai/code/session_01WT3uDc26XFEw3aMy8rJgJ3