### PR TITLE
fix: rename test workflow to CI and add unique gate name

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,7 +74,7 @@ jobs:
           node dist/cli.mjs --version
 
   required:
-    # name 変更時は infra 側も更新する
+    # name 変更時は infra 側の required_status_checks も更新する
     name: CI / required
     needs: [changes, test]
     if: always()

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: Test
+name: CI
 
 on:
   pull_request:
@@ -74,6 +74,8 @@ jobs:
           node dist/cli.mjs --version
 
   required:
+    # name 変更時は infra 側も更新する
+    name: CI / required
     needs: [changes, test]
     if: always()
     runs-on: ubuntu-slim

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,7 +16,7 @@ defaults:
 
 jobs:
   changes:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     timeout-minutes: 5
     permissions:
       contents: read # required by actions/checkout to fetch repository code and dorny/paths-filter to diff against the base ref
@@ -77,7 +77,7 @@ jobs:
   required:
     needs: [changes, test]
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     timeout-minutes: 1
     steps:
       - name: Fail if any required job failed or was cancelled

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,16 +21,15 @@ jobs:
     permissions:
       contents: read # required by actions/checkout to fetch repository code and dorny/paths-filter to diff against the base ref
     outputs:
-      src: ${{ steps.filter.outputs.src }}
+      src: ${{ steps.changes.outputs.src }}
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
-      - name: Detect changes
-        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
-        id: filter
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: changes
         with:
           filters: |
             src:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,20 +16,21 @@ defaults:
 
 jobs:
   changes:
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
       contents: read # required by actions/checkout to fetch repository code and dorny/paths-filter to diff against the base ref
     outputs:
-      src: ${{ steps.changes.outputs.src }}
+      src: ${{ steps.filter.outputs.src }}
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
-      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
-        id: changes
+      - name: Detect changes
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: filter
         with:
           filters: |
             src:
@@ -76,7 +77,7 @@ jobs:
   required:
     needs: [changes, test]
     if: always()
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     timeout-minutes: 1
     steps:
       - name: Fail if any required job failed or was cancelled


### PR DESCRIPTION
## 概要

- test.yaml を ci.yaml にリネーム、workflow name を CI に統一
- required ゲートジョブにユニークな name (`CI / required`) を付与

ruleset の `test` → `CI / required` 更新は PR マージ後に実施。

https://claude.ai/code/session_01TkQRPr4KydLk53utjxtLRJ