### PR TITLE
chore: follow @nozomiishii/tsconfig v2 breaking change

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@nozomiishii/eslint-config": "1.13.0",
     "@nozomiishii/lefthook-config": "1.13.0",
     "@nozomiishii/prettier-config": "1.13.0",
-    "@nozomiishii/tsconfig": "2.0.0",
+    "@nozomiishii/tsconfig": "2.0.1",
     "@types/node": "24.13.3",
     "eslint": "10.8.0",
     "lefthook": "2.1.10",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@nozomiishii/eslint-config": "1.13.0",
     "@nozomiishii/lefthook-config": "1.13.0",
     "@nozomiishii/prettier-config": "1.13.0",
-    "@nozomiishii/tsconfig": "2.0.1",
+    "@nozomiishii/tsconfig": "2.1.0",
     "@types/node": "24.13.3",
     "eslint": "10.8.0",
     "lefthook": "2.1.10",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@nozomiishii/eslint-config": "1.13.0",
     "@nozomiishii/lefthook-config": "1.13.0",
     "@nozomiishii/prettier-config": "1.13.0",
-    "@nozomiishii/tsconfig": "1.13.0",
+    "@nozomiishii/tsconfig": "2.0.0",
     "@types/node": "24.13.3",
     "eslint": "10.8.0",
     "lefthook": "2.1.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: 1.13.0
         version: 1.13.0(prettier@3.9.6)
       '@nozomiishii/tsconfig':
-        specifier: 1.13.0
-        version: 1.13.0
+        specifier: 2.0.0
+        version: 2.0.0
       '@types/node':
         specifier: 24.13.3
         version: 24.13.3
@@ -748,8 +748,8 @@ packages:
     peerDependencies:
       prettier: 3.9.6
 
-  '@nozomiishii/tsconfig@1.13.0':
-    resolution: {integrity: sha512-ONGAsxPZYNdLLv84cLoqH3jo1otuu8XIIA3BMcfX0eLysBh4mbP6DxCHvrJd1crYUlEcUcqvXfUXNDa0lRHKUQ==}
+  '@nozomiishii/tsconfig@2.0.0':
+    resolution: {integrity: sha512-xRrMUfqjc4QP+KSCNvARw31k+f3gIhg6LmnQparU90mASiTEhC6XmjbIWsJaivuhC9Fp4us94Nh8hR2JY0sZKQ==}
 
   '@octokit/auth-token@4.0.0':
     resolution: {integrity: sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==}
@@ -4916,7 +4916,7 @@ snapshots:
       prettier: 3.9.6
       prettier-plugin-packagejson: 3.0.2(prettier@3.9.6)
 
-  '@nozomiishii/tsconfig@1.13.0': {}
+  '@nozomiishii/tsconfig@2.0.0': {}
 
   '@octokit/auth-token@4.0.0': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: 1.13.0
         version: 1.13.0(prettier@3.9.6)
       '@nozomiishii/tsconfig':
-        specifier: 2.0.1
-        version: 2.0.1
+        specifier: 2.1.0
+        version: 2.1.0
       '@types/node':
         specifier: 24.13.3
         version: 24.13.3
@@ -748,8 +748,8 @@ packages:
     peerDependencies:
       prettier: 3.9.6
 
-  '@nozomiishii/tsconfig@2.0.1':
-    resolution: {integrity: sha512-UaQ6Y/D7kFgvobgC/3m57u0kZQ07xyQ/z7faRUS79LAmkVb3dnaSF1DA1sizUW2II7kjKx7pFaj3g3/zIMdrIg==}
+  '@nozomiishii/tsconfig@2.1.0':
+    resolution: {integrity: sha512-PE5ga1gM/MOdfG2II9Fijt03XhU714HOPXV2q/SD9HqFDZugpIo5j5HkEPYPXGT+QN9RoZPDeNuga1rE2+pFKQ==}
 
   '@octokit/auth-token@4.0.0':
     resolution: {integrity: sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==}
@@ -4916,7 +4916,7 @@ snapshots:
       prettier: 3.9.6
       prettier-plugin-packagejson: 3.0.2(prettier@3.9.6)
 
-  '@nozomiishii/tsconfig@2.0.1': {}
+  '@nozomiishii/tsconfig@2.1.0': {}
 
   '@octokit/auth-token@4.0.0': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: 1.13.0
         version: 1.13.0(prettier@3.9.6)
       '@nozomiishii/tsconfig':
-        specifier: 2.0.0
-        version: 2.0.0
+        specifier: 2.0.1
+        version: 2.0.1
       '@types/node':
         specifier: 24.13.3
         version: 24.13.3
@@ -748,8 +748,8 @@ packages:
     peerDependencies:
       prettier: 3.9.6
 
-  '@nozomiishii/tsconfig@2.0.0':
-    resolution: {integrity: sha512-xRrMUfqjc4QP+KSCNvARw31k+f3gIhg6LmnQparU90mASiTEhC6XmjbIWsJaivuhC9Fp4us94Nh8hR2JY0sZKQ==}
+  '@nozomiishii/tsconfig@2.0.1':
+    resolution: {integrity: sha512-UaQ6Y/D7kFgvobgC/3m57u0kZQ07xyQ/z7faRUS79LAmkVb3dnaSF1DA1sizUW2II7kjKx7pFaj3g3/zIMdrIg==}
 
   '@octokit/auth-token@4.0.0':
     resolution: {integrity: sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==}
@@ -4916,7 +4916,7 @@ snapshots:
       prettier: 3.9.6
       prettier-plugin-packagejson: 3.0.2(prettier@3.9.6)
 
-  '@nozomiishii/tsconfig@2.0.0': {}
+  '@nozomiishii/tsconfig@2.0.1': {}
 
   '@octokit/auth-token@4.0.0': {}
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,6 @@
 {
   "extends": "@nozomiishii/tsconfig/tsconfig.json",
   "compilerOptions": {
-    "types": ["node"],
-    // await using / Symbol.asyncDispose の型は ES2025 lib に無いため ESNext.Disposable を足す
-    "lib": ["ES2025", "ESNext.Disposable"]
+    "types": ["node"]
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
-  "extends": "@nozomiishii/tsconfig/tsconfig.bundler.json",
+  "extends": "@nozomiishii/tsconfig/tsconfig.json",
   "compilerOptions": {
     "types": ["node"],
-    // await using / Symbol.asyncDispose の型は ES2024 lib に無いため ESNext.Disposable を足す
-    "lib": ["ES2024", "ESNext.Disposable"]
+    // await using / Symbol.asyncDispose の型は ES2025 lib に無いため ESNext.Disposable を足す
+    "lib": ["ES2025", "ESNext.Disposable"]
   }
 }


### PR DESCRIPTION
## 概要

[@nozomiishii/tsconfig v2.0.0](https://github.com/nozomiishii/configs/pull/2698) の破壊的変更に追従する。base preset が typecheck 専用 (`noEmit: true`) になり、`tsconfig.bundler.json` が削除された。

## 変更内容

- `@nozomiishii/tsconfig` を `2.0.0` に更新
- `extends` を `@nozomiishii/tsconfig/tsconfig.bundler.json` から `@nozomiishii/tsconfig/tsconfig.json` に変更
- `lib` を `["ES2024", "ESNext.Disposable"]` から `["ES2025", "ESNext.Disposable"]` に更新

削除された `tsconfig.bundler.json` の役割 (`noEmit: true`) は base に昇格したため、base を extends するだけで同じ挙動になる。emit は従来どおり tsdown が担当する。

`lib` は `await using` / `Symbol.asyncDispose` の型のために明示指定が必要だが、base の `lib` が `ES2025` になったため、`ES2024` のままだと base より低い上書きになってしまう。base に合わせて `ES2025` へ揃えた。

## 検証

- `pnpm exec tsc` 成功
