### PR TITLE
chore: make the docs readable at a glance

### DIFF
--- a/docs/brand-color.md
+++ b/docs/brand-color.md
@@ -8,14 +8,18 @@
 - 0 → FF = 育ち始めから育ちきるまでな感じ
 - 39 = サンクス！収穫！
 
-メモ:
-- コード内では「稲光」や「Inabikari」の名前は使わず `BRAND_COLOR` / `ブランドカラー` にする
-- 使用箇所
-    - wordmark `git harvest`
-    - `✓` 成功マーカー
-    - `→` will-delete マーカー
-    - `logo` subcommand
-- `·` 削除せず保護 と reason 文は dim gray
-- エラーは terminal default red を維持して CLI 規約（red=error / yellow=warn）と衝突させない
-- light terminal での視認性は犠牲にして(ごめん) dark terminal 前提（`#C0FF39` は L≈0.83 なので白背景では飛ぶ）
-- `NO_COLOR=1` と 非 TTY ではプレーンテキスト fallback
+コード内では「稲光」や「Inabikari」の名前は使わず `BRAND_COLOR` / `ブランドカラー` にする。
+
+## 配色
+
+| 色 | 使う場所 |
+| --- | --- |
+| ブランドカラー | wordmark `git harvest`、`✓` 成功マーカー、`→` will-delete マーカー、`logo` subcommand |
+| dim gray | `·` 削除せず保護、reason 文 |
+| terminal default red | エラー |
+
+エラーだけ terminal default red のままにするのは、CLI 規約（red=error / yellow=warn）と衝突させないため。
+
+dark terminal 前提で、light terminal での視認性は犠牲にする（ごめん）。`#C0FF39` は L≈0.83 なので白背景では飛ぶ。
+
+`NO_COLOR=1` と 非 TTY ではプレーンテキストに fallback する。


### PR DESCRIPTION
## 概要

docs を、流し読みでも意図が伝わる形に書き直す。nozomiishii/infra で先に適用した方針を横展開したもの。

- 文章で説明していた構造・フロー・対比を図と表にする
- 前提を知らないと読めない並びを組み替える
- 同じ説明が複数箇所にあれば 1 箇所に集約する

書き方の規則は [doc スキルの文章ガイドライン](https://github.com/nozomiishii/dotfiles/blob/main/home/.agents/skills/doc/SKILL.md)。図の形式は「同じ repo の既存 docs に合わせ、前例が無ければ ASCII、ループや合流で線が引けないときだけ Mermaid」に従い、今回は全て ASCII。

技術的な内容・コマンド・パス・URL・数値は変えていない。

## 変更内容

`docs/brand-color.md`

- 「メモ:」の 1 リストに命名規約・使用箇所・他の色・fallback が混在していたので分解した
- 色と使う場所の対応を表にした
- 図は入れていない。順序も分岐もないため
- 由来とニーモニックは原文のまま
