### PR TITLE
chore: drop redundant --frozen-lockfile from CI workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,7 +61,7 @@ jobs:
           cache: ${{ runner.environment == 'github-hosted' }}
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install
 
       - name: Run tests
         run: pnpm test

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -71,7 +71,7 @@ jobs:
           cache: ${{ runner.environment == 'github-hosted' }}
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install
 
       - name: Run release-please github-release
         env:
@@ -143,7 +143,7 @@ jobs:
           cache: ${{ runner.environment == 'github-hosted' }}
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install
 
       - name: Publish to npm
         run: pnpm publish --no-git-checks
@@ -190,7 +190,7 @@ jobs:
           cache: ${{ runner.environment == 'github-hosted' }}
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install
 
       - name: Run release-please release-pr
         env:


### PR DESCRIPTION
## 変更
CI workflow の `pnpm install` から `--frozen-lockfile` を削除した。

## 理由
lockfile があれば CI 環境ではデフォルトで on になるため、明示指定は冗長。

> This setting is `true` by default in CI environments.

— [pnpm docs: `--frozen-lockfile`](https://pnpm.io/cli/install#--frozen-lockfile)

CI 環境ではないローカルの git hook や docs 内の記述は対象外。

## 検証
nozomiishii/design [#30](https://github.com/nozomiishii/design/pull/30) で先に同じ変更を入れ、フラグあり / なしのジョブログを比較して install の挙動が変わらないことを確認済み。この repo では actionlint が通ることを確認した。
